### PR TITLE
Added handler for queue/leaderboard/match msg deletion

### DIFF
--- a/src/events/messageDelete.ts
+++ b/src/events/messageDelete.ts
@@ -1,0 +1,84 @@
+import { mongoError } from "#utilities";
+import { Client } from "discord.js";
+import { BotEvent, IGuild, ILeaderboard, IMatch, IQueue, IQueuePlayer } from "../types";
+import { MongooseError } from "mongoose";
+import Guild from "#schemas/guild";
+import Leaderboard from "#schemas/leaderboard";
+import Match from "#schemas/match";
+import Queue from "#schemas/queue";
+import QueuePlayer from "#schemas/queuePlayer";
+
+const event: BotEvent = {
+    name: 'messageDelete',
+    async execute(message, client: Client) {
+        var guildRecord = await Guild.findOne<IGuild>({
+            guildId: message.guildId,
+        });
+        if (message.channelId === guildRecord?.leaderboardChannelId) {
+            const leaderboardQuery = Leaderboard.findOne<ILeaderboard>().and([{ messageId: message.id}]);
+            try {
+                await Leaderboard.deleteOne(leaderboardQuery);
+            } catch(error) {
+                mongoError(error as MongooseError);
+                await message.reply({
+                    content: `There was an error deleting the leaderboard in the database.`,
+                    ephemeral: true
+                });
+            }
+        } else if (message.channelId === guildRecord?.queueChannelId) {
+            const queueQuery = await Queue.findOne<IQueue>().and([{messageId: message.id}]);
+            const queueMessageId = queueQuery?.messageId;
+            const queuePlayersQuery = await QueuePlayer.find<IQueuePlayer>().and([{messageId: queueMessageId, matchMessageId: {$exists: false}}]);
+            try {
+                await Queue.deleteOne().and([{messageId: queueQuery?.messageId}]);
+            } catch(error) {
+                mongoError(error as MongooseError);
+                await message.reply({
+                    content: `There was an error deleting the queue from the queues in the database.`,
+                    ephemeral: true
+                });
+            }
+            try {
+                await Promise.all(queuePlayersQuery.map(async (u) => {
+                    await QueuePlayer.deleteOne({ _id: u._id });
+                }));
+            } catch(error) {
+                mongoError(error as MongooseError);
+                await message.reply({
+                    content: `There was an error deleting the plaayers from the queueplayers in the database.`,
+                    ephemeral: true
+                });
+            }
+        } else if (message.channelId === guildRecord?.matchChannelId) {
+            const matchQuery = await Match.findOne<IMatch>().and([{messageId: message.id, matchWinner: {$exists: false}}]);
+            if (!matchQuery) return;
+            try {
+                await Match.deleteOne().and([{messageId: matchQuery?.messageId}]);
+            } catch(error) {
+                mongoError(error as MongooseError);
+                await message.reply({
+                    content: `There was an error deleting the match from the matches in the database.`,
+                    ephemeral: true
+                });
+                return;
+            }
+            try {
+                const queuePlayersQuery = await QueuePlayer.find<IQueuePlayer>().and([{matchMessageId: matchQuery?.messageId}]);
+                await Promise.all(queuePlayersQuery.map(async (u) => {
+                    await QueuePlayer.deleteOne({ _id: u._id });
+                }));
+            } catch(error) {
+                mongoError(error as MongooseError);
+                await message.reply({
+                    content: `There was an error deleting the players from the queueplayers in the database.`,
+                    ephemeral: true
+                });
+                return;
+            }
+
+        }
+
+    },
+};
+
+export default event;


### PR DESCRIPTION
Handles the following when their respective messages are deleted in Discord:
- Removes queue and queueplayers with the same messageId and don't have a matchMessageId
- Removes match and removes the players from queueplayers if the match does not have a 'matchWinner' field
- Removes the leaderboard data from leaderboards so shouldn't cause edge case of deleting/creating a ton of leaderboards and filling DB