### PR TITLE
Fixing queue limit checking for rankMin/rankMax

### DIFF
--- a/src/operations/buttons/queueButtons.ts
+++ b/src/operations/buttons/queueButtons.ts
@@ -48,13 +48,13 @@ export const processQueue = (interaction: ButtonInteraction, client: Client, pla
                 return;
             }
             if (!queryResults[4]) return;
-            /*if (!(queryResults[0].rating > queryResults[4].rankMin && queryResults[0].rating < queryResults[4].rankMax)) {
+            if (!(queryResults[0].rating >= queryResults[4].rankMin && queryResults[0].rating <= queryResults[4].rankMax)) {
                 await interaction.reply({
                     content: `Your rating: ${queryResults[0].rating} must be between ${queryResults[4].rankMin} and ${queryResults[4].rankMax}`,
                     ephemeral: true
                 });
                 return;
-            }*/
+            }
 
             // if the player is ready we want to save to the DB
             if(playerReady) {


### PR DESCRIPTION
I know this limit checking is currently being used in the queue system. So I don't know if the bot is currently being ran based on this main branch since this limit checking was commented out. But the limits just needed equal signs and the code uncommented.