### PR TITLE
Allow multi-queuing, fix crash when 14+ players queue, fix remove player button bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,45 +125,46 @@
 			"optional": true
 		},
 		"node_modules/@aws-sdk/client-cognito-identity": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.382.0.tgz",
-			"integrity": "sha512-EgKpWh5w2uWNzjtcD3S3JLSuuwLvvaeaVih60xNEoyaxpqwgjAe0vw/8GT9q2nqhS0J+B3bQVYdkCyA5oQDVEQ==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.421.0.tgz",
+			"integrity": "sha512-9htG14uDA/2XhU+vRhBcCG8GAOJ29rV53cxlc6I1YRKD6imXdU+X0ZfMPZCkPjEPGT4hHTpO0vR2J7zY8FXfzg==",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/client-sts": "3.382.0",
-				"@aws-sdk/credential-provider-node": "3.382.0",
-				"@aws-sdk/middleware-host-header": "3.379.1",
-				"@aws-sdk/middleware-logger": "3.378.0",
-				"@aws-sdk/middleware-recursion-detection": "3.378.0",
-				"@aws-sdk/middleware-signing": "3.379.1",
-				"@aws-sdk/middleware-user-agent": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
-				"@aws-sdk/util-endpoints": "3.382.0",
-				"@aws-sdk/util-user-agent-browser": "3.378.0",
-				"@aws-sdk/util-user-agent-node": "3.378.0",
-				"@smithy/config-resolver": "^2.0.1",
-				"@smithy/fetch-http-handler": "^2.0.1",
-				"@smithy/hash-node": "^2.0.1",
-				"@smithy/invalid-dependency": "^2.0.1",
-				"@smithy/middleware-content-length": "^2.0.1",
-				"@smithy/middleware-endpoint": "^2.0.1",
-				"@smithy/middleware-retry": "^2.0.1",
-				"@smithy/middleware-serde": "^2.0.1",
-				"@smithy/middleware-stack": "^2.0.0",
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/node-http-handler": "^2.0.1",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/smithy-client": "^2.0.1",
-				"@smithy/types": "^2.0.2",
-				"@smithy/url-parser": "^2.0.1",
+				"@aws-sdk/client-sts": "3.421.0",
+				"@aws-sdk/credential-provider-node": "3.421.0",
+				"@aws-sdk/middleware-host-header": "3.418.0",
+				"@aws-sdk/middleware-logger": "3.418.0",
+				"@aws-sdk/middleware-recursion-detection": "3.418.0",
+				"@aws-sdk/middleware-signing": "3.418.0",
+				"@aws-sdk/middleware-user-agent": "3.418.0",
+				"@aws-sdk/region-config-resolver": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
+				"@aws-sdk/util-endpoints": "3.418.0",
+				"@aws-sdk/util-user-agent-browser": "3.418.0",
+				"@aws-sdk/util-user-agent-node": "3.418.0",
+				"@smithy/config-resolver": "^2.0.10",
+				"@smithy/fetch-http-handler": "^2.1.5",
+				"@smithy/hash-node": "^2.0.9",
+				"@smithy/invalid-dependency": "^2.0.9",
+				"@smithy/middleware-content-length": "^2.0.11",
+				"@smithy/middleware-endpoint": "^2.0.9",
+				"@smithy/middleware-retry": "^2.0.12",
+				"@smithy/middleware-serde": "^2.0.9",
+				"@smithy/middleware-stack": "^2.0.2",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/node-http-handler": "^2.1.5",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/smithy-client": "^2.1.6",
+				"@smithy/types": "^2.3.3",
+				"@smithy/url-parser": "^2.0.9",
 				"@smithy/util-base64": "^2.0.0",
 				"@smithy/util-body-length-browser": "^2.0.0",
-				"@smithy/util-body-length-node": "^2.0.0",
-				"@smithy/util-defaults-mode-browser": "^2.0.1",
-				"@smithy/util-defaults-mode-node": "^2.0.1",
-				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.1.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.10",
+				"@smithy/util-defaults-mode-node": "^2.0.12",
+				"@smithy/util-retry": "^2.0.2",
 				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			},
@@ -172,86 +173,43 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.382.0.tgz",
-			"integrity": "sha512-ge11t4hJllOF8pBNF0p1X52lLqUsLGAoey24fvk3fyvvczeLpegGYh2kdLG0iwFTDgRxaUqK+kboH5Wy9ux/pw==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.421.0.tgz",
+			"integrity": "sha512-40CmW7K2/FZEn3CbOjbpRYeVjKu6aJQlpRHcAgEJGNoVEAnRA3YNH4H0BN2iWWITfYg3B7sIjMm5VE9fCIK1Ng==",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/middleware-host-header": "3.379.1",
-				"@aws-sdk/middleware-logger": "3.378.0",
-				"@aws-sdk/middleware-recursion-detection": "3.378.0",
-				"@aws-sdk/middleware-user-agent": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
-				"@aws-sdk/util-endpoints": "3.382.0",
-				"@aws-sdk/util-user-agent-browser": "3.378.0",
-				"@aws-sdk/util-user-agent-node": "3.378.0",
-				"@smithy/config-resolver": "^2.0.1",
-				"@smithy/fetch-http-handler": "^2.0.1",
-				"@smithy/hash-node": "^2.0.1",
-				"@smithy/invalid-dependency": "^2.0.1",
-				"@smithy/middleware-content-length": "^2.0.1",
-				"@smithy/middleware-endpoint": "^2.0.1",
-				"@smithy/middleware-retry": "^2.0.1",
-				"@smithy/middleware-serde": "^2.0.1",
-				"@smithy/middleware-stack": "^2.0.0",
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/node-http-handler": "^2.0.1",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/smithy-client": "^2.0.1",
-				"@smithy/types": "^2.0.2",
-				"@smithy/url-parser": "^2.0.1",
+				"@aws-sdk/middleware-host-header": "3.418.0",
+				"@aws-sdk/middleware-logger": "3.418.0",
+				"@aws-sdk/middleware-recursion-detection": "3.418.0",
+				"@aws-sdk/middleware-user-agent": "3.418.0",
+				"@aws-sdk/region-config-resolver": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
+				"@aws-sdk/util-endpoints": "3.418.0",
+				"@aws-sdk/util-user-agent-browser": "3.418.0",
+				"@aws-sdk/util-user-agent-node": "3.418.0",
+				"@smithy/config-resolver": "^2.0.10",
+				"@smithy/fetch-http-handler": "^2.1.5",
+				"@smithy/hash-node": "^2.0.9",
+				"@smithy/invalid-dependency": "^2.0.9",
+				"@smithy/middleware-content-length": "^2.0.11",
+				"@smithy/middleware-endpoint": "^2.0.9",
+				"@smithy/middleware-retry": "^2.0.12",
+				"@smithy/middleware-serde": "^2.0.9",
+				"@smithy/middleware-stack": "^2.0.2",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/node-http-handler": "^2.1.5",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/smithy-client": "^2.1.6",
+				"@smithy/types": "^2.3.3",
+				"@smithy/url-parser": "^2.0.9",
 				"@smithy/util-base64": "^2.0.0",
 				"@smithy/util-body-length-browser": "^2.0.0",
-				"@smithy/util-body-length-node": "^2.0.0",
-				"@smithy/util-defaults-mode-browser": "^2.0.1",
-				"@smithy/util-defaults-mode-node": "^2.0.1",
-				"@smithy/util-retry": "^2.0.0",
-				"@smithy/util-utf8": "^2.0.0",
-				"tslib": "^2.5.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso-oidc": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.382.0.tgz",
-			"integrity": "sha512-hTfvB1ftbrqaz7qiEkmRobzUQwG34oZlByobn8Frdr5ZQbJk969bX6evQAPyKlJEr26+kL9TnaX+rbLR/+gwHQ==",
-			"optional": true,
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "3.0.0",
-				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/middleware-host-header": "3.379.1",
-				"@aws-sdk/middleware-logger": "3.378.0",
-				"@aws-sdk/middleware-recursion-detection": "3.378.0",
-				"@aws-sdk/middleware-user-agent": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
-				"@aws-sdk/util-endpoints": "3.382.0",
-				"@aws-sdk/util-user-agent-browser": "3.378.0",
-				"@aws-sdk/util-user-agent-node": "3.378.0",
-				"@smithy/config-resolver": "^2.0.1",
-				"@smithy/fetch-http-handler": "^2.0.1",
-				"@smithy/hash-node": "^2.0.1",
-				"@smithy/invalid-dependency": "^2.0.1",
-				"@smithy/middleware-content-length": "^2.0.1",
-				"@smithy/middleware-endpoint": "^2.0.1",
-				"@smithy/middleware-retry": "^2.0.1",
-				"@smithy/middleware-serde": "^2.0.1",
-				"@smithy/middleware-stack": "^2.0.0",
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/node-http-handler": "^2.0.1",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/smithy-client": "^2.0.1",
-				"@smithy/types": "^2.0.2",
-				"@smithy/url-parser": "^2.0.1",
-				"@smithy/util-base64": "^2.0.0",
-				"@smithy/util-body-length-browser": "^2.0.0",
-				"@smithy/util-body-length-node": "^2.0.0",
-				"@smithy/util-defaults-mode-browser": "^2.0.1",
-				"@smithy/util-defaults-mode-node": "^2.0.1",
-				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.1.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.10",
+				"@smithy/util-defaults-mode-node": "^2.0.12",
+				"@smithy/util-retry": "^2.0.2",
 				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			},
@@ -260,45 +218,46 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sts": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.382.0.tgz",
-			"integrity": "sha512-G5wgahrOqmrljjyLVGASIZUXIIdalbCo0z4PuFHdb2R2CVfwO8renfgrmk4brT9tIxIfen5bRA7ftXMe7yrgRA==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.421.0.tgz",
+			"integrity": "sha512-/92NOZMcdkBcvGrINk5B/l+6DGcVzYE4Ab3ME4vcY9y//u2gd0yNn5YYRSzzjVBLvhDP3u6CbTfLX2Bm4qihPw==",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/credential-provider-node": "3.382.0",
-				"@aws-sdk/middleware-host-header": "3.379.1",
-				"@aws-sdk/middleware-logger": "3.378.0",
-				"@aws-sdk/middleware-recursion-detection": "3.378.0",
-				"@aws-sdk/middleware-sdk-sts": "3.379.1",
-				"@aws-sdk/middleware-signing": "3.379.1",
-				"@aws-sdk/middleware-user-agent": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
-				"@aws-sdk/util-endpoints": "3.382.0",
-				"@aws-sdk/util-user-agent-browser": "3.378.0",
-				"@aws-sdk/util-user-agent-node": "3.378.0",
-				"@smithy/config-resolver": "^2.0.1",
-				"@smithy/fetch-http-handler": "^2.0.1",
-				"@smithy/hash-node": "^2.0.1",
-				"@smithy/invalid-dependency": "^2.0.1",
-				"@smithy/middleware-content-length": "^2.0.1",
-				"@smithy/middleware-endpoint": "^2.0.1",
-				"@smithy/middleware-retry": "^2.0.1",
-				"@smithy/middleware-serde": "^2.0.1",
-				"@smithy/middleware-stack": "^2.0.0",
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/node-http-handler": "^2.0.1",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/smithy-client": "^2.0.1",
-				"@smithy/types": "^2.0.2",
-				"@smithy/url-parser": "^2.0.1",
+				"@aws-sdk/credential-provider-node": "3.421.0",
+				"@aws-sdk/middleware-host-header": "3.418.0",
+				"@aws-sdk/middleware-logger": "3.418.0",
+				"@aws-sdk/middleware-recursion-detection": "3.418.0",
+				"@aws-sdk/middleware-sdk-sts": "3.418.0",
+				"@aws-sdk/middleware-signing": "3.418.0",
+				"@aws-sdk/middleware-user-agent": "3.418.0",
+				"@aws-sdk/region-config-resolver": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
+				"@aws-sdk/util-endpoints": "3.418.0",
+				"@aws-sdk/util-user-agent-browser": "3.418.0",
+				"@aws-sdk/util-user-agent-node": "3.418.0",
+				"@smithy/config-resolver": "^2.0.10",
+				"@smithy/fetch-http-handler": "^2.1.5",
+				"@smithy/hash-node": "^2.0.9",
+				"@smithy/invalid-dependency": "^2.0.9",
+				"@smithy/middleware-content-length": "^2.0.11",
+				"@smithy/middleware-endpoint": "^2.0.9",
+				"@smithy/middleware-retry": "^2.0.12",
+				"@smithy/middleware-serde": "^2.0.9",
+				"@smithy/middleware-stack": "^2.0.2",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/node-http-handler": "^2.1.5",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/smithy-client": "^2.1.6",
+				"@smithy/types": "^2.3.3",
+				"@smithy/url-parser": "^2.0.9",
 				"@smithy/util-base64": "^2.0.0",
 				"@smithy/util-body-length-browser": "^2.0.0",
-				"@smithy/util-body-length-node": "^2.0.0",
-				"@smithy/util-defaults-mode-browser": "^2.0.1",
-				"@smithy/util-defaults-mode-node": "^2.0.1",
-				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.1.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.10",
+				"@smithy/util-defaults-mode-node": "^2.0.12",
+				"@smithy/util-retry": "^2.0.2",
 				"@smithy/util-utf8": "^2.0.0",
 				"fast-xml-parser": "4.2.5",
 				"tslib": "^2.5.0"
@@ -308,15 +267,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-cognito-identity": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.382.0.tgz",
-			"integrity": "sha512-fEsmPSylpQdALSS1pKMa9QghMk9xFiQCanmUWbQ7ETkcjuYuc/DK6GIA0pRjq/BROJJNSxKrSxt3TZPzVpvb3w==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.421.0.tgz",
+			"integrity": "sha512-x+C7nonKomdBAljTAPtqhU6Xzzaqy08PV1vO5Cp/YYMye+uOGQ2+1x7cfaY5uIHZbbNRUhCmUBKGnwsUyTB1cQ==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/client-cognito-identity": "3.421.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -324,14 +283,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.378.0.tgz",
-			"integrity": "sha512-B2OVdO9kBClDwGgWTBLAQwFV8qYTYGyVujg++1FZFSFMt8ORFdZ5fNpErvJtiSjYiOOQMzyBeSNhKyYNXCiJjQ==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.418.0.tgz",
+			"integrity": "sha512-e74sS+x63EZUBO+HaI8zor886YdtmULzwKdctsZp5/37Xho1CVUNtEC+fYa69nigBD9afoiH33I4JggaHgrekQ==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -339,20 +298,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.382.0.tgz",
-			"integrity": "sha512-31pi44WWri2WQmagqptUv7x3Nq8pQ6H06OCQx5goEm77SosSdwQwyBPrS9Pg0yI9aljFAxF+rZ75degsCorbQg==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.421.0.tgz",
+			"integrity": "sha512-J5yH/gkpAk6FMeH5F9u5Nr6oG+97tj1kkn5q49g3XMbtWw7GiynadxdtoRBCeIg1C7o2LOQx4B1AnhNhIw1z/g==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.378.0",
-				"@aws-sdk/credential-provider-process": "3.378.0",
-				"@aws-sdk/credential-provider-sso": "3.382.0",
-				"@aws-sdk/credential-provider-web-identity": "3.378.0",
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/credential-provider-env": "3.418.0",
+				"@aws-sdk/credential-provider-process": "3.418.0",
+				"@aws-sdk/credential-provider-sso": "3.421.0",
+				"@aws-sdk/credential-provider-web-identity": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/credential-provider-imds": "^2.0.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/shared-ini-file-loader": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/shared-ini-file-loader": "^2.0.6",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -360,21 +319,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.382.0.tgz",
-			"integrity": "sha512-q6AWCCb0E0cH/Y5Dtln0QssbCBXDbV4PoTV3EdRuGoJcHyNfHJ8X0mqcc7k44wG4Piazu+ufZThvn43W7W9a4g==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.421.0.tgz",
+			"integrity": "sha512-g1dvdvfDj0u8B/gOsHR3o1arP4O4QE/dFm2IJBYr/eUdKISMUgbQULWtg4zdtAf0Oz4xN0723i7fpXAF1gTnRA==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.378.0",
-				"@aws-sdk/credential-provider-ini": "3.382.0",
-				"@aws-sdk/credential-provider-process": "3.378.0",
-				"@aws-sdk/credential-provider-sso": "3.382.0",
-				"@aws-sdk/credential-provider-web-identity": "3.378.0",
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/credential-provider-env": "3.418.0",
+				"@aws-sdk/credential-provider-ini": "3.421.0",
+				"@aws-sdk/credential-provider-process": "3.418.0",
+				"@aws-sdk/credential-provider-sso": "3.421.0",
+				"@aws-sdk/credential-provider-web-identity": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/credential-provider-imds": "^2.0.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/shared-ini-file-loader": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/shared-ini-file-loader": "^2.0.6",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -382,15 +341,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.378.0.tgz",
-			"integrity": "sha512-KFTIy7u+wXj3eDua4rgS0tODzMnXtXhAm1RxzCW9FL5JLBBrd82ymCj1Dp72217Sw5Do6NjCnDTTNkCHZMA77w==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.418.0.tgz",
+			"integrity": "sha512-xPbdm2WKz1oH6pTkrJoUmr3OLuqvvcPYTQX0IIlc31tmDwDWPQjXGGFD/vwZGIZIkKaFpFxVMgAzfFScxox7dw==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/shared-ini-file-loader": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/shared-ini-file-loader": "^2.0.6",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -398,17 +357,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.382.0.tgz",
-			"integrity": "sha512-tKCQKqxnAHeRD7pQNmDmLWwC7pt5koo6yiQTVQ382U+8xx7BNsApE1zdC4LrtrVN1FYqVbw5kXjYFtSCtaUxGA==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.421.0.tgz",
+			"integrity": "sha512-f8T3L5rhImL6T6RTSvbOxaWw9k2fDOT2DZbNjcPz9ITWmwXj2NNbdHGWuRi3dv2HoY/nW2IJdNxnhdhbn6Fc1A==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.382.0",
-				"@aws-sdk/token-providers": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/client-sso": "3.421.0",
+				"@aws-sdk/token-providers": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/shared-ini-file-loader": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/shared-ini-file-loader": "^2.0.6",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -416,14 +375,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.378.0.tgz",
-			"integrity": "sha512-GWjydOszhc4xDF8xuPtBvboglXQr0gwCW1oHAvmLcOT38+Hd6qnKywnMSeoXYRPgoKfF9TkWQgW1jxplzCG0UA==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.418.0.tgz",
+			"integrity": "sha512-do7ang565n9p3dS1JdsQY01rUfRx8vkxQqz5M8OlcEHBNiCdi2PvSjNwcBdrv/FKkyIxZb0TImOfBSt40hVdxQ==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -431,25 +390,25 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-providers": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.382.0.tgz",
-			"integrity": "sha512-+emgPCb8t5ODLpE1GeCkKaI6lx9M3RLQCYBGYkm/2o8FyvNeob9IBs6W8ufUTlnl4YRdKjDOlcfDtS00wCVHfA==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.421.0.tgz",
+			"integrity": "sha512-Mhz3r2N0YlOAhb1ZZYrP76VA1aIlJZw3IAwYwlS+hO4sAwp8iY6wCKiumqplXkVgK+ObLxlS9W/aW+2SAKsB7w==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.382.0",
-				"@aws-sdk/client-sso": "3.382.0",
-				"@aws-sdk/client-sts": "3.382.0",
-				"@aws-sdk/credential-provider-cognito-identity": "3.382.0",
-				"@aws-sdk/credential-provider-env": "3.378.0",
-				"@aws-sdk/credential-provider-ini": "3.382.0",
-				"@aws-sdk/credential-provider-node": "3.382.0",
-				"@aws-sdk/credential-provider-process": "3.378.0",
-				"@aws-sdk/credential-provider-sso": "3.382.0",
-				"@aws-sdk/credential-provider-web-identity": "3.378.0",
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/client-cognito-identity": "3.421.0",
+				"@aws-sdk/client-sso": "3.421.0",
+				"@aws-sdk/client-sts": "3.421.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.421.0",
+				"@aws-sdk/credential-provider-env": "3.418.0",
+				"@aws-sdk/credential-provider-ini": "3.421.0",
+				"@aws-sdk/credential-provider-node": "3.421.0",
+				"@aws-sdk/credential-provider-process": "3.418.0",
+				"@aws-sdk/credential-provider-sso": "3.421.0",
+				"@aws-sdk/credential-provider-web-identity": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/credential-provider-imds": "^2.0.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -457,14 +416,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.379.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.379.1.tgz",
-			"integrity": "sha512-LI4KpAFWNWVr2aH2vRVblr0Y8tvDz23lj8LOmbDmCrzd5M21nxuocI/8nEAQj55LiTIf9Zs+dHCdsyegnFXdrA==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.418.0.tgz",
+			"integrity": "sha512-LrMTdzalkPw/1ujLCKPLwCGvPMCmT4P+vOZQRbSEVZPnlZk+Aj++aL/RaHou0jL4kJH3zl8iQepriBt4a7UvXQ==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.378.0",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/types": "3.418.0",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -472,13 +431,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.378.0.tgz",
-			"integrity": "sha512-l1DyaDLm3KeBMNMuANI3scWh8Xvu248x+vw6Z7ExWOhGXFmQ1MW7YvASg/SdxWkhlF9HmkkTif1LdMB22x6QDA==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.418.0.tgz",
+			"integrity": "sha512-StKGmyPVfoO/wdNTtKemYwoJsqIl4l7oqarQY7VSf2Mp3mqaa+njLViHsQbirYpyqpgUEusOnuTlH5utxJ1NsQ==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.378.0",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/types": "3.418.0",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -486,14 +445,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.378.0.tgz",
-			"integrity": "sha512-mUMfHAz0oGNIWiTZHTVJb+I515Hqs2zx1j36Le4MMiiaMkPW1SRUF1FIwGuc1wh6E8jB5q+XfEMriDjRi4TZRA==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.418.0.tgz",
+			"integrity": "sha512-kKFrIQglBLUFPbHSDy1+bbe3Na2Kd70JSUC3QLMbUHmqipXN8KeXRfAj7vTv97zXl0WzG0buV++WcNwOm1rFjg==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.378.0",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/types": "3.418.0",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -501,14 +460,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-sdk-sts": {
-			"version": "3.379.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.379.1.tgz",
-			"integrity": "sha512-SK3gSyT0XbLiY12+AjLFYL9YngxOXHnZF3Z33Cdd4a+AUYrVBV7JBEEGD1Nlwrcmko+3XgaKlmgUaR5s91MYvg==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.418.0.tgz",
+			"integrity": "sha512-cW8ijrCTP+mgihvcq4+TbhAcE/we5lFl4ydRqvTdtcSnYQAVQADg47rnTScQiFsPFEB3NKq7BGeyTJF9MKolPA==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/middleware-signing": "3.379.1",
-				"@aws-sdk/types": "3.378.0",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/middleware-signing": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -516,17 +475,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-signing": {
-			"version": "3.379.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.379.1.tgz",
-			"integrity": "sha512-kBk2ZUvR84EM4fICjr8K+Ykpf8SI1UzzPp2/UVYZ0X+4H/ZCjfSqohGRwHykMqeplne9qHSL7/rGJs1H3l3gPg==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.418.0.tgz",
+			"integrity": "sha512-onvs5KoYQE8OlOE740RxWBGtsUyVIgAo0CzRKOQO63ZEYqpL1Os+MS1CGzdNhvQnJgJruE1WW+Ix8fjN30zKPA==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/protocol-http": "^3.0.5",
 				"@smithy/signature-v4": "^2.0.0",
-				"@smithy/types": "^2.0.2",
-				"@smithy/util-middleware": "^2.0.0",
+				"@smithy/types": "^2.3.3",
+				"@smithy/util-middleware": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -534,15 +493,31 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.382.0.tgz",
-			"integrity": "sha512-LFRW1jmXOrOAd3911ktn6oaYmuurNnulbdRMOUdwz99GGdLVFipQhOi9idKswb8IOhPa4jEVQt25Kcv7ctvu0A==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.418.0.tgz",
+			"integrity": "sha512-Jdcztg9Tal9SEAL0dKRrnpKrm6LFlWmAhvuwv0dQ7bNTJxIxyEFbpqdgy7mpQHsLVZgq1Aad/7gT/72c9igyZw==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.378.0",
-				"@aws-sdk/util-endpoints": "3.382.0",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/types": "3.418.0",
+				"@aws-sdk/util-endpoints": "3.418.0",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/types": "^2.3.3",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.418.0.tgz",
+			"integrity": "sha512-lJRZ/9TjZU6yLz+mAwxJkcJZ6BmyYoIJVo1p5+BN//EFdEmC8/c0c9gXMRzfISV/mqWSttdtccpAyN4/goHTYA==",
+			"optional": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/types": "^2.3.3",
+				"@smithy/util-config-provider": "^2.0.0",
+				"@smithy/util-middleware": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -550,16 +525,45 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.382.0.tgz",
-			"integrity": "sha512-axn4IyPpHdkXi8G06KCB3tPz79DipZFFH9N9YVDpLMnDYTdfX36HGdYzINaQc+z+XPbEpa1ZpoIzWScHRjFjdg==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.418.0.tgz",
+			"integrity": "sha512-9P7Q0VN0hEzTngy3Sz5eya2qEOEf0Q8qf1vB3um0gE6ID6EVAdz/nc/DztfN32MFxk8FeVBrCP5vWdoOzmd72g==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/client-sso-oidc": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/middleware-host-header": "3.418.0",
+				"@aws-sdk/middleware-logger": "3.418.0",
+				"@aws-sdk/middleware-recursion-detection": "3.418.0",
+				"@aws-sdk/middleware-user-agent": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
+				"@aws-sdk/util-endpoints": "3.418.0",
+				"@aws-sdk/util-user-agent-browser": "3.418.0",
+				"@aws-sdk/util-user-agent-node": "3.418.0",
+				"@smithy/config-resolver": "^2.0.10",
+				"@smithy/fetch-http-handler": "^2.1.5",
+				"@smithy/hash-node": "^2.0.9",
+				"@smithy/invalid-dependency": "^2.0.9",
+				"@smithy/middleware-content-length": "^2.0.11",
+				"@smithy/middleware-endpoint": "^2.0.9",
+				"@smithy/middleware-retry": "^2.0.12",
+				"@smithy/middleware-serde": "^2.0.9",
+				"@smithy/middleware-stack": "^2.0.2",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/node-http-handler": "^2.1.5",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/shared-ini-file-loader": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/shared-ini-file-loader": "^2.0.6",
+				"@smithy/smithy-client": "^2.1.6",
+				"@smithy/types": "^2.3.3",
+				"@smithy/url-parser": "^2.0.9",
+				"@smithy/util-base64": "^2.0.0",
+				"@smithy/util-body-length-browser": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.1.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.10",
+				"@smithy/util-defaults-mode-node": "^2.0.12",
+				"@smithy/util-retry": "^2.0.2",
+				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -567,12 +571,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.378.0.tgz",
-			"integrity": "sha512-qP0CvR/ItgktmN8YXpGQglzzR/6s0nrsQ4zIfx3HMwpsBTwuouYahcCtF1Vr82P4NFcoDA412EJahJ2pIqEd+w==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.418.0.tgz",
+			"integrity": "sha512-y4PQSH+ulfFLY0+FYkaK4qbIaQI9IJNMO2xsxukW6/aNoApNymN1D2FSi2la8Qbp/iPjNDKsG8suNPm9NtsWXQ==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -580,12 +584,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.382.0.tgz",
-			"integrity": "sha512-flajPyjmjNG67fXk7l4GoTB/7J11VBqtFZXuuAZKhKU07Ia3IQupsFqNf5lV8D44ZgjnKH0fTGnv3dUALjW7Wg==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.418.0.tgz",
+			"integrity": "sha512-sYSDwRTl7yE7LhHkPzemGzmIXFVHSsi3AQ1KeNEk84eBqxMHHcCc2kqklaBk2roXWe50QDgRMy1ikZUxvtzNHQ==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/types": "3.418.0",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -605,26 +609,26 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.378.0.tgz",
-			"integrity": "sha512-FSCpagzftK1W+m7Ar6lpX7/Gr9y5P56nhFYz8U4EYQ4PkufS6czWX9YW+/FA5OYV0vlQ/SvPqMnzoHIPUNhZrQ==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.418.0.tgz",
+			"integrity": "sha512-c4p4mc0VV/jIeNH0lsXzhJ1MpWRLuboGtNEpqE4s1Vl9ck2amv9VdUUZUmHbg+bVxlMgRQ4nmiovA4qIrqGuyg==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.378.0",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/types": "3.418.0",
+				"@smithy/types": "^2.3.3",
 				"bowser": "^2.11.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.378.0.tgz",
-			"integrity": "sha512-IdwVJV0E96MkJeFte4dlWqvB+oiqCiZ5lOlheY3W9NynTuuX0GGYNC8Y9yIsV8Oava1+ujpJq0ww6qXdYxmO4A==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.418.0.tgz",
+			"integrity": "sha512-BXMskXFtg+dmzSCgmnWOffokxIbPr1lFqa1D9kvM3l3IFRiFGx2IyDg+8MAhq11aPDLvoa/BDuQ0Yqma5izOhg==",
 			"optional": true,
 			"dependencies": {
-				"@aws-sdk/types": "3.378.0",
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/types": "3.418.0",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -762,6 +766,15 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
+		"node_modules/@mongodb-js/saslprep": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+			"integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+			"optional": true,
+			"dependencies": {
+				"sparse-bitfield": "^3.0.3"
+			}
+		},
 		"node_modules/@sapphire/async-queue": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
@@ -794,12 +807,12 @@
 			}
 		},
 		"node_modules/@smithy/abort-controller": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.1.tgz",
-			"integrity": "sha512-0s7XjIbsTwZyUW9OwXQ8J6x1UiA1TNCh60Vaw56nHahL7kUZsLhmTlWiaxfLkFtO2Utkj8YewcpHTYpxaTzO+w==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.9.tgz",
+			"integrity": "sha512-8liHOEbx99xcy4VndeQNQhyA0LS+e7UqsuRnDTSIA26IKBv/7vA9w09KOd4fgNULrvX0r3WpA6cwsQTRJpSWkg==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -807,14 +820,15 @@
 			}
 		},
 		"node_modules/@smithy/config-resolver": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.1.tgz",
-			"integrity": "sha512-l83Pm7hV+8CBQOCmBRopWDtF+CURUJol7NsuPYvimiDhkC2F8Ba9T1imSFE+pD1UIJ9jlsDPAnZfPJT5cjnuEw==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.10.tgz",
+			"integrity": "sha512-MwToDsCltHjumkCuRn883qoNeJUawc2b8sX9caSn5vLz6J5crU1IklklNxWCaMO2z2nDL91Po4b/aI1eHv5PfA==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-config-provider": "^2.0.0",
-				"@smithy/util-middleware": "^2.0.0",
+				"@smithy/util-middleware": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -822,15 +836,15 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.1.tgz",
-			"integrity": "sha512-8VxriuRINNEfVZjEFKBY75y9ZWAx73DZ5K/u+3LmB6r8WR2h3NaFxFKMlwlq0uzNdGhD1ouKBn9XWEGYHKiPLw==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.12.tgz",
+			"integrity": "sha512-S3lUNe+2fEFwKcmiQniXGPXt69vaHvQCw8kYQOBL4OvJsgwfpkIYDZdroHbTshYi0M6WaKL26Mw+hvgma6dZqA==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/property-provider": "^2.0.1",
-				"@smithy/types": "^2.0.2",
-				"@smithy/url-parser": "^2.0.1",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/property-provider": "^2.0.10",
+				"@smithy/types": "^2.3.3",
+				"@smithy/url-parser": "^2.0.9",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -838,37 +852,37 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-codec": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.1.tgz",
-			"integrity": "sha512-/IiNB7gQM2y2ZC/GAWOWDa8+iXfhr1g9Xe5979cQEOdCWDISvrAiv18cn3OtIQUhbYOR3gm7QtCpkq1to2takQ==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.9.tgz",
+			"integrity": "sha512-sy0pcbKnawt1iu+qCoSFbs/h9PAaUgvlJEO3lqkE1HFFj4p5RgL98vH+9CyDoj6YY82cG5XsorFmcLqQJHTOYw==",
 			"optional": true,
 			"dependencies": {
 				"@aws-crypto/crc32": "3.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-hex-encoding": "^2.0.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.1.tgz",
-			"integrity": "sha512-/SoU/ClazgcdOxgE4zA7RX8euiELwpsrKCSvulVQvu9zpmqJRyEJn8ZTWYFV17/eHOBdHTs9kqodhNhsNT+cUw==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.1.5.tgz",
+			"integrity": "sha512-BIeCHGfr5JCGN+EMTwZK74ELvjPXOIrI7OLM5OhZJJ6AmZyRv2S9ANJk18AtLwht0TsSm+8WoXIEp8LuxNgUyA==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/querystring-builder": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/querystring-builder": "^2.0.9",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-base64": "^2.0.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"node_modules/@smithy/hash-node": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.1.tgz",
-			"integrity": "sha512-oTKYimQdF4psX54ZonpcIE+MXjMUWFxLCNosjPkJPFQ9whRX0K/PFX/+JZGRQh3zO9RlEOEUIbhy9NO+Wha6hw==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.9.tgz",
+			"integrity": "sha512-XP3yWd5wyCtiVmsY5Nuq/FUwyCEQ6YG7DsvRh7ThldNukGpCzyFdP8eivZJVjn4Fx7oYrrOnVoYZ0WEgpW1AvQ==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-buffer-from": "^2.0.0",
 				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
@@ -878,12 +892,12 @@
 			}
 		},
 		"node_modules/@smithy/invalid-dependency": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.1.tgz",
-			"integrity": "sha512-2q/Eb0AE662zwyMV+z+TL7deBwcHCgaZZGc0RItamBE8kak3MzCi/EZCNoFWoBfxgQ4jfR12wm8KKsSXhJzJtQ==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.9.tgz",
+			"integrity": "sha512-RuJqhYf8nViK96IIO9JbTtjDUuFItVfuuJhWw2yk7fv67yltQ7fZD6IQ2OsHHluoVmstnQJuCg5raXJR696Ubw==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
@@ -900,13 +914,13 @@
 			}
 		},
 		"node_modules/@smithy/middleware-content-length": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.1.tgz",
-			"integrity": "sha512-IZhRSk5GkVBcrKaqPXddBS2uKhaqwBgaSgbBb1OJyGsKe7SxRFbclWS0LqOR9fKUkDl+3lL8E2ffpo6EQg0igw==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.11.tgz",
+			"integrity": "sha512-Malj4voNTL4+a5ZL3a6+Ij7JTUMTa2R7c3ZIBzMxN5OUUgAspU7uFi1Q97f4B0afVh2joQBAWH5IQJUG25nl8g==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -914,15 +928,15 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.1.tgz",
-			"integrity": "sha512-uz/KI1MBd9WHrrkVFZO4L4Wyv24raf0oR4EsOYEeG5jPJO5U+C7MZGLcMxX8gWERDn1sycBDqmGv8fjUMLxT6w==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.9.tgz",
+			"integrity": "sha512-72/o8R6AAO4+nyTI6h4z6PYGTSA4dr1M7tZz29U8DEUHuh1YkhC77js0P6RyF9G0wDLuYqxb+Yh0crI5WG2pJg==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/middleware-serde": "^2.0.1",
-				"@smithy/types": "^2.0.2",
-				"@smithy/url-parser": "^2.0.1",
-				"@smithy/util-middleware": "^2.0.0",
+				"@smithy/middleware-serde": "^2.0.9",
+				"@smithy/types": "^2.3.3",
+				"@smithy/url-parser": "^2.0.9",
+				"@smithy/util-middleware": "^2.0.2",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -930,16 +944,17 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.1.tgz",
-			"integrity": "sha512-NKHF4i0gjSyjO6C0ZyjEpNqzGgIu7s8HOK6oT/1Jqws2Q1GynR1xV8XTUs1gKXeaNRzbzKQRewHHmfPwZjOtHA==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.12.tgz",
+			"integrity": "sha512-YQ/ufXX4/d9/+Jf1QQ4J+CVeupC7BW52qldBTvRV33PDX9vxndlAwkFwzBcmnUFC3Hjf1//HW6I77EItcjNSCA==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/service-error-classification": "^2.0.0",
-				"@smithy/types": "^2.0.2",
-				"@smithy/util-middleware": "^2.0.0",
-				"@smithy/util-retry": "^2.0.0",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/service-error-classification": "^2.0.2",
+				"@smithy/types": "^2.3.3",
+				"@smithy/util-middleware": "^2.0.2",
+				"@smithy/util-retry": "^2.0.2",
 				"tslib": "^2.5.0",
 				"uuid": "^8.3.2"
 			},
@@ -948,12 +963,12 @@
 			}
 		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.1.tgz",
-			"integrity": "sha512-uKxPaC6ItH9ZXdpdqNtf8sda7GcU4SPMp0tomq/5lUg9oiMa/Q7+kD35MUrpKaX3IVXVrwEtkjCU9dogZ/RAUA==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.9.tgz",
+			"integrity": "sha512-GVbauxrr6WmtCaesakktg3t5LR/yDbajpC7KkWc8rtCpddMI4ShAVO5Q6DqwX8MDFi4CLaY8H7eTGcxhl3jbLg==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -961,11 +976,12 @@
 			}
 		},
 		"node_modules/@smithy/middleware-stack": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz",
-			"integrity": "sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.3.tgz",
+			"integrity": "sha512-AlhPmbwpkC4lQBVaVHXczmjFvsAhDHhrakqLt038qFLotnJcvDLhmMzAtu23alBeOSkKxkTQq0LsAt2N0WpAbw==",
 			"optional": true,
 			"dependencies": {
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -973,14 +989,14 @@
 			}
 		},
 		"node_modules/@smithy/node-config-provider": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.1.tgz",
-			"integrity": "sha512-Zoel4CPkKRTQ2XxmozZUfqBYqjPKL53/SvTDhJHj+VBSiJy6MXRav1iDCyFPS92t40Uh+Yi+Km5Ch3hQ+c/zSA==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.12.tgz",
+			"integrity": "sha512-df9y9ywv+JmS40Y60ZqJ4jfZiTCmyHQffwzIqjBjLJLJl0imf9F6DWBd+jiEWHvlohR+sFhyY+KL/qzKgnAq1A==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/property-provider": "^2.0.1",
-				"@smithy/shared-ini-file-loader": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/property-provider": "^2.0.10",
+				"@smithy/shared-ini-file-loader": "^2.0.11",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -988,15 +1004,15 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.1.tgz",
-			"integrity": "sha512-Zv3fxk3p9tsmPT2CKMsbuwbbxnq2gzLDIulxv+yI6aE+02WPYorObbbe9gh7SW3weadMODL1vTfOoJ9yFypDzg==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.5.tgz",
+			"integrity": "sha512-52uF+BrZaFiBh+NT/bADiVDCQO91T+OwDRsuaAeWZC1mlCXFjAPPQdxeQohtuYOe9m7mPP/xIMNiqbe8jvndHA==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/abort-controller": "^2.0.1",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/querystring-builder": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/abort-controller": "^2.0.9",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/querystring-builder": "^2.0.9",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1004,12 +1020,12 @@
 			}
 		},
 		"node_modules/@smithy/property-provider": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.1.tgz",
-			"integrity": "sha512-pmJRyY9SF6sutWIktIhe+bUdSQDxv/qZ4mYr3/u+u45riTPN7nmRxPo+e4sjWVoM0caKFjRSlj3tf5teRFy0Vg==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.10.tgz",
+			"integrity": "sha512-YMBVfh0ZMmJtbsUn+WfSwR32iRljZPdRN0Tn2GAcdJ+ejX8WrBXD7Z0jIkQDrQZr8fEuuv5x8WxMIj+qVbsPQw==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1017,12 +1033,12 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.1.tgz",
-			"integrity": "sha512-mrkMAp0wtaDEIkgRObWYxI1Kun1tm6Iu6rK+X4utb6Ah7Uc3Kk4VIWwK/rBHdYGReiLIrxFCB1rq4a2gyZnSgg==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.5.tgz",
+			"integrity": "sha512-3t3fxj+ip4EPHRC2fQ0JimMxR/qCQ1LSQJjZZVZFgROnFLYWPDgUZqpoi7chr+EzatxJVXF/Rtoi5yLHOWCoZQ==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1030,12 +1046,12 @@
 			}
 		},
 		"node_modules/@smithy/querystring-builder": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.1.tgz",
-			"integrity": "sha512-bp+93WFzx1FojVEIeFPtG0A1pKsFdCUcZvVdZdRlmNooOUrz9Mm9bneRd8hDwAQ37pxiZkCOxopSXXRQN10mYw==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.9.tgz",
+			"integrity": "sha512-Yt6CPF4j3j1cuwod/DRflbuXxBFjJm7gAjy6W1RE21Rz5/kfGFqiZBXWmmXwGtnnhiLThYwoHK4S6/TQtnx0Fg==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-uri-escape": "^2.0.0",
 				"tslib": "^2.5.0"
 			},
@@ -1044,12 +1060,12 @@
 			}
 		},
 		"node_modules/@smithy/querystring-parser": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.1.tgz",
-			"integrity": "sha512-h+e7k1z+IvI2sSbUBG9Aq46JsgLl4UqIUl6aigAlRBj+P6ocNXpM6Yn1vMBw5ijtXeZbYpd1YvCxwDgdw3jhmg==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.9.tgz",
+			"integrity": "sha512-U6z4N743s4vrcxPW8p8+reLV0PjMCYEyb1/wtMVvv3VnbJ74gshdI8SR1sBnEh95cF8TxonmX5IxY25tS9qGfg==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1057,21 +1073,24 @@
 			}
 		},
 		"node_modules/@smithy/service-error-classification": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz",
-			"integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.2.tgz",
+			"integrity": "sha512-GTUd2j63gKy7A+ggvSdn2hc4sejG7LWfE+ZMF17vzWoNyqERWbRP7HTPS0d0Lwg1p6OQCAzvNigSrEIWVFt6iA==",
 			"optional": true,
+			"dependencies": {
+				"@smithy/types": "^2.3.3"
+			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.1.tgz",
-			"integrity": "sha512-a463YiZrPGvM+F336rIF8pLfQsHAdCRAn/BiI/EWzg5xLoxbC7GSxIgliDDXrOu0z8gT3nhVsif85eU6jyct3A==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.11.tgz",
+			"integrity": "sha512-Sf0u5C5px6eykXi6jImDTp+edvG3REtPjXnFWU/J+b7S2wkXwUqFXqBL5DdM4zC1F+M8u57ZT7NRqDwMOw7/Tw==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1079,16 +1098,16 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.1.tgz",
-			"integrity": "sha512-jztv5Mirca42ilxmMDjzLdXcoAmRhZskGafGL49sRo5u7swEZcToEFrq6vtX5YMbSyTVrE9Teog5EFexY5Ff2Q==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.9.tgz",
+			"integrity": "sha512-RkHP0joSI1j2EI+mU55sOi33/aMMkKdL9ZY+SWrPxsiCe1oyzzuy79Tpn8X7uT+t0ilNmQlwPpkP/jUy940pEA==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/eventstream-codec": "^2.0.1",
+				"@smithy/eventstream-codec": "^2.0.9",
 				"@smithy/is-array-buffer": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-hex-encoding": "^2.0.0",
-				"@smithy/util-middleware": "^2.0.0",
+				"@smithy/util-middleware": "^2.0.2",
 				"@smithy/util-uri-escape": "^2.0.0",
 				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
@@ -1098,14 +1117,14 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.1.tgz",
-			"integrity": "sha512-LHC5m6tYpEu1iNbONfvMbwtErboyTZJfEIPoD78Ei5MVr36vZQCaCla5mvo36+q/a2NAk2//fA5Rx3I1Kf7+lQ==",
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.7.tgz",
+			"integrity": "sha512-r6T/oiBQ8vCbGqObH4/h0YqD0jFB1hAS9KFRmuTfaNJueu/L2hjmjqFjv3PV5lkbNHTgUYraSv4cFQ1naxiELQ==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/middleware-stack": "^2.0.0",
-				"@smithy/types": "^2.0.2",
-				"@smithy/util-stream": "^2.0.1",
+				"@smithy/middleware-stack": "^2.0.3",
+				"@smithy/types": "^2.3.3",
+				"@smithy/util-stream": "^2.0.12",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1113,9 +1132,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.0.2.tgz",
-			"integrity": "sha512-wcymEjIXQ9+NEfE5Yt5TInAqe1o4n+Nh+rh00AwoazppmUt8tdo6URhc5gkDcOYrcvlDVAZE7uG69nDpEGUKxw==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.3.tgz",
+			"integrity": "sha512-zTdIPR9PvFVNRdIKMQu4M5oyTaycIbUqLheQqaOi9rTWPkgjGO2wDBxMA1rBHQB81aqAEv+DbSS4jfKyQMnXRA==",
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.5.0"
@@ -1125,13 +1144,13 @@
 			}
 		},
 		"node_modules/@smithy/url-parser": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.1.tgz",
-			"integrity": "sha512-NpHVOAwddo+OyyIoujDL9zGL96piHWrTNXqltWmBvlUoWgt1HPyBuKs6oHjioyFnNZXUqveTOkEEq0U5w6Uv8A==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.9.tgz",
+			"integrity": "sha512-NBnJ0NiY8z6E82Xd5VYUFQfKwK/wA/+QkKmpYUYP+cpH3aCzE6g2gvixd9vQKYjsIdRfNPCf+SFAozt8ljozOw==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/querystring-parser": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/querystring-parser": "^2.0.9",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
@@ -1158,9 +1177,9 @@
 			}
 		},
 		"node_modules/@smithy/util-body-length-node": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.0.0.tgz",
-			"integrity": "sha512-ZV7Z/WHTMxHJe/xL/56qZwSUcl63/5aaPAGjkfynJm4poILjdD4GmFI+V+YWabh2WJIjwTKZ5PNsuvPQKt93Mg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+			"integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.5.0"
@@ -1195,13 +1214,14 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.1.tgz",
-			"integrity": "sha512-w72Qwsb+IaEYEFtYICn0Do42eFju78hTaBzzJfT107lFOPdbjWjKnFutV+6GL/nZd5HWXY7ccAKka++C3NrjHw==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.11.tgz",
+			"integrity": "sha512-0syV1Mz/mCQ7CG/MHKQfH+w86xq59jpD0EOXv5oe0WBXLmq2lWPpVHl2Y6+jQ+/9fYzyZ5NF+NC/WEIuiv690A==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/property-provider": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/property-provider": "^2.0.10",
+				"@smithy/smithy-client": "^2.1.7",
+				"@smithy/types": "^2.3.3",
 				"bowser": "^2.11.0",
 				"tslib": "^2.5.0"
 			},
@@ -1210,16 +1230,17 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.1.tgz",
-			"integrity": "sha512-dNF45caelEBambo0SgkzQ0v76m4YM+aFKZNTtSafy7P5dVF8TbjZuR2UX1A5gJABD9XK6lzN+v/9Yfzj/EDgGg==",
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.13.tgz",
+			"integrity": "sha512-6BtCHYdw5Z8r6KpW8tRCc3yURgvcQwfIEeHhR70BeSOfx8T/TXPPjb8A+K45+KASspa3fzrsSxeIwB0sAeMoHA==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/config-resolver": "^2.0.1",
-				"@smithy/credential-provider-imds": "^2.0.1",
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/property-provider": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/config-resolver": "^2.0.10",
+				"@smithy/credential-provider-imds": "^2.0.12",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/property-provider": "^2.0.10",
+				"@smithy/smithy-client": "^2.1.7",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1239,11 +1260,12 @@
 			}
 		},
 		"node_modules/@smithy/util-middleware": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.0.tgz",
-			"integrity": "sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.2.tgz",
+			"integrity": "sha512-UGPZM+Ja/vke5pc/S8G0LNiHpVirtjppsXO+GK9m9wbzRGzPJTfnZA/gERUUN/AfxEy/8SL7U1kd7u4t2X8K1w==",
 			"optional": true,
 			"dependencies": {
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1251,12 +1273,13 @@
 			}
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.0.tgz",
-			"integrity": "sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.2.tgz",
+			"integrity": "sha512-ovWiayUB38moZcLhSFFfUgB2IMb7R1JfojU20qSahjxAgfOZvDWme3eOYUMtAVnouZ9kYJiFgHLy27qRH4NeeA==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/service-error-classification": "^2.0.0",
+				"@smithy/service-error-classification": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1264,14 +1287,14 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.1.tgz",
-			"integrity": "sha512-2a0IOtwIKC46EEo7E7cxDN8u2jwOiYYJqcFKA6rd5rdXqKakHT2Gc+AqHWngr0IEHUfW92zX12wRQKwyoqZf2Q==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.12.tgz",
+			"integrity": "sha512-FOCpRLaj6gvSyUC5mJAACT+sPMPmp9sD1o+hVbUH/QxwZfulypA3ZIFdAg/59/IY0d/1Q4CTztsiHEB5LgjN4g==",
 			"optional": true,
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^2.0.1",
-				"@smithy/node-http-handler": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/fetch-http-handler": "^2.1.5",
+				"@smithy/node-http-handler": "^2.1.5",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-base64": "^2.0.0",
 				"@smithy/util-buffer-from": "^2.0.0",
 				"@smithy/util-hex-encoding": "^2.0.0",
@@ -1338,9 +1361,9 @@
 			"integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
 		},
 		"node_modules/@types/webidl-conversions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-			"integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.1.tgz",
+			"integrity": "sha512-8hKOnOan+Uu+NgMaCouhg3cT9x5fFZ92Jwf+uDLXLu/MFRbXxlWwGeQY7KVHkeSft6RvY+tdxklUBuyY9eIEKg=="
 		},
 		"node_modules/@types/whatwg-url": {
 			"version": "8.2.2",
@@ -1688,12 +1711,12 @@
 			"optional": true
 		},
 		"node_modules/mongodb": {
-			"version": "4.16.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.16.0.tgz",
-			"integrity": "sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==",
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.1.tgz",
+			"integrity": "sha512-MBuyYiPUPRTqfH2dV0ya4dcr2E5N52ocBuZ8Sgg/M030nGF78v855B3Z27mZJnp8PxjnUquEnAtjOsphgMZOlQ==",
 			"dependencies": {
 				"bson": "^4.7.2",
-				"mongodb-connection-string-url": "^2.5.4",
+				"mongodb-connection-string-url": "^2.6.0",
 				"socks": "^2.7.1"
 			},
 			"engines": {
@@ -1701,7 +1724,7 @@
 			},
 			"optionalDependencies": {
 				"@aws-sdk/credential-providers": "^3.186.0",
-				"saslprep": "^1.0.3"
+				"@mongodb-js/saslprep": "^1.1.0"
 			}
 		},
 		"node_modules/mongodb-connection-string-url": {
@@ -1714,13 +1737,13 @@
 			}
 		},
 		"node_modules/mongoose": {
-			"version": "6.11.5",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.11.5.tgz",
-			"integrity": "sha512-ZarPe1rCHG4aVb78xLuok4BBIm0HMz/Y/CjxYXCk3Qz1mEhS7bPMy6ZhSX2/Dng//R7ei8719j6K87UVM/1b3g==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.12.0.tgz",
+			"integrity": "sha512-sd/q83C6TBRPBrrD2A/POSbA/exbCFM2WOuY7Lf2JuIJFlHFG39zYSDTTAEiYlzIfahNOLmXPxBGFxdAch41Mw==",
 			"dependencies": {
 				"bson": "^4.7.2",
 				"kareem": "2.5.1",
-				"mongodb": "4.16.0",
+				"mongodb": "4.17.1",
 				"mpath": "0.9.0",
 				"mquery": "4.0.3",
 				"ms": "2.1.3",
@@ -1824,18 +1847,6 @@
 					"url": "https://feross.org/support"
 				}
 			]
-		},
-		"node_modules/saslprep": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-			"optional": true,
-			"dependencies": {
-				"sparse-bitfield": "^3.0.3"
-			},
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/sift": {
 			"version": "16.0.1",
@@ -2209,407 +2220,411 @@
 			}
 		},
 		"@aws-sdk/client-cognito-identity": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.382.0.tgz",
-			"integrity": "sha512-EgKpWh5w2uWNzjtcD3S3JLSuuwLvvaeaVih60xNEoyaxpqwgjAe0vw/8GT9q2nqhS0J+B3bQVYdkCyA5oQDVEQ==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.421.0.tgz",
+			"integrity": "sha512-9htG14uDA/2XhU+vRhBcCG8GAOJ29rV53cxlc6I1YRKD6imXdU+X0ZfMPZCkPjEPGT4hHTpO0vR2J7zY8FXfzg==",
 			"optional": true,
 			"requires": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/client-sts": "3.382.0",
-				"@aws-sdk/credential-provider-node": "3.382.0",
-				"@aws-sdk/middleware-host-header": "3.379.1",
-				"@aws-sdk/middleware-logger": "3.378.0",
-				"@aws-sdk/middleware-recursion-detection": "3.378.0",
-				"@aws-sdk/middleware-signing": "3.379.1",
-				"@aws-sdk/middleware-user-agent": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
-				"@aws-sdk/util-endpoints": "3.382.0",
-				"@aws-sdk/util-user-agent-browser": "3.378.0",
-				"@aws-sdk/util-user-agent-node": "3.378.0",
-				"@smithy/config-resolver": "^2.0.1",
-				"@smithy/fetch-http-handler": "^2.0.1",
-				"@smithy/hash-node": "^2.0.1",
-				"@smithy/invalid-dependency": "^2.0.1",
-				"@smithy/middleware-content-length": "^2.0.1",
-				"@smithy/middleware-endpoint": "^2.0.1",
-				"@smithy/middleware-retry": "^2.0.1",
-				"@smithy/middleware-serde": "^2.0.1",
-				"@smithy/middleware-stack": "^2.0.0",
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/node-http-handler": "^2.0.1",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/smithy-client": "^2.0.1",
-				"@smithy/types": "^2.0.2",
-				"@smithy/url-parser": "^2.0.1",
+				"@aws-sdk/client-sts": "3.421.0",
+				"@aws-sdk/credential-provider-node": "3.421.0",
+				"@aws-sdk/middleware-host-header": "3.418.0",
+				"@aws-sdk/middleware-logger": "3.418.0",
+				"@aws-sdk/middleware-recursion-detection": "3.418.0",
+				"@aws-sdk/middleware-signing": "3.418.0",
+				"@aws-sdk/middleware-user-agent": "3.418.0",
+				"@aws-sdk/region-config-resolver": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
+				"@aws-sdk/util-endpoints": "3.418.0",
+				"@aws-sdk/util-user-agent-browser": "3.418.0",
+				"@aws-sdk/util-user-agent-node": "3.418.0",
+				"@smithy/config-resolver": "^2.0.10",
+				"@smithy/fetch-http-handler": "^2.1.5",
+				"@smithy/hash-node": "^2.0.9",
+				"@smithy/invalid-dependency": "^2.0.9",
+				"@smithy/middleware-content-length": "^2.0.11",
+				"@smithy/middleware-endpoint": "^2.0.9",
+				"@smithy/middleware-retry": "^2.0.12",
+				"@smithy/middleware-serde": "^2.0.9",
+				"@smithy/middleware-stack": "^2.0.2",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/node-http-handler": "^2.1.5",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/smithy-client": "^2.1.6",
+				"@smithy/types": "^2.3.3",
+				"@smithy/url-parser": "^2.0.9",
 				"@smithy/util-base64": "^2.0.0",
 				"@smithy/util-body-length-browser": "^2.0.0",
-				"@smithy/util-body-length-node": "^2.0.0",
-				"@smithy/util-defaults-mode-browser": "^2.0.1",
-				"@smithy/util-defaults-mode-node": "^2.0.1",
-				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.1.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.10",
+				"@smithy/util-defaults-mode-node": "^2.0.12",
+				"@smithy/util-retry": "^2.0.2",
 				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/client-sso": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.382.0.tgz",
-			"integrity": "sha512-ge11t4hJllOF8pBNF0p1X52lLqUsLGAoey24fvk3fyvvczeLpegGYh2kdLG0iwFTDgRxaUqK+kboH5Wy9ux/pw==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.421.0.tgz",
+			"integrity": "sha512-40CmW7K2/FZEn3CbOjbpRYeVjKu6aJQlpRHcAgEJGNoVEAnRA3YNH4H0BN2iWWITfYg3B7sIjMm5VE9fCIK1Ng==",
 			"optional": true,
 			"requires": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/middleware-host-header": "3.379.1",
-				"@aws-sdk/middleware-logger": "3.378.0",
-				"@aws-sdk/middleware-recursion-detection": "3.378.0",
-				"@aws-sdk/middleware-user-agent": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
-				"@aws-sdk/util-endpoints": "3.382.0",
-				"@aws-sdk/util-user-agent-browser": "3.378.0",
-				"@aws-sdk/util-user-agent-node": "3.378.0",
-				"@smithy/config-resolver": "^2.0.1",
-				"@smithy/fetch-http-handler": "^2.0.1",
-				"@smithy/hash-node": "^2.0.1",
-				"@smithy/invalid-dependency": "^2.0.1",
-				"@smithy/middleware-content-length": "^2.0.1",
-				"@smithy/middleware-endpoint": "^2.0.1",
-				"@smithy/middleware-retry": "^2.0.1",
-				"@smithy/middleware-serde": "^2.0.1",
-				"@smithy/middleware-stack": "^2.0.0",
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/node-http-handler": "^2.0.1",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/smithy-client": "^2.0.1",
-				"@smithy/types": "^2.0.2",
-				"@smithy/url-parser": "^2.0.1",
+				"@aws-sdk/middleware-host-header": "3.418.0",
+				"@aws-sdk/middleware-logger": "3.418.0",
+				"@aws-sdk/middleware-recursion-detection": "3.418.0",
+				"@aws-sdk/middleware-user-agent": "3.418.0",
+				"@aws-sdk/region-config-resolver": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
+				"@aws-sdk/util-endpoints": "3.418.0",
+				"@aws-sdk/util-user-agent-browser": "3.418.0",
+				"@aws-sdk/util-user-agent-node": "3.418.0",
+				"@smithy/config-resolver": "^2.0.10",
+				"@smithy/fetch-http-handler": "^2.1.5",
+				"@smithy/hash-node": "^2.0.9",
+				"@smithy/invalid-dependency": "^2.0.9",
+				"@smithy/middleware-content-length": "^2.0.11",
+				"@smithy/middleware-endpoint": "^2.0.9",
+				"@smithy/middleware-retry": "^2.0.12",
+				"@smithy/middleware-serde": "^2.0.9",
+				"@smithy/middleware-stack": "^2.0.2",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/node-http-handler": "^2.1.5",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/smithy-client": "^2.1.6",
+				"@smithy/types": "^2.3.3",
+				"@smithy/url-parser": "^2.0.9",
 				"@smithy/util-base64": "^2.0.0",
 				"@smithy/util-body-length-browser": "^2.0.0",
-				"@smithy/util-body-length-node": "^2.0.0",
-				"@smithy/util-defaults-mode-browser": "^2.0.1",
-				"@smithy/util-defaults-mode-node": "^2.0.1",
-				"@smithy/util-retry": "^2.0.0",
-				"@smithy/util-utf8": "^2.0.0",
-				"tslib": "^2.5.0"
-			}
-		},
-		"@aws-sdk/client-sso-oidc": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.382.0.tgz",
-			"integrity": "sha512-hTfvB1ftbrqaz7qiEkmRobzUQwG34oZlByobn8Frdr5ZQbJk969bX6evQAPyKlJEr26+kL9TnaX+rbLR/+gwHQ==",
-			"optional": true,
-			"requires": {
-				"@aws-crypto/sha256-browser": "3.0.0",
-				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/middleware-host-header": "3.379.1",
-				"@aws-sdk/middleware-logger": "3.378.0",
-				"@aws-sdk/middleware-recursion-detection": "3.378.0",
-				"@aws-sdk/middleware-user-agent": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
-				"@aws-sdk/util-endpoints": "3.382.0",
-				"@aws-sdk/util-user-agent-browser": "3.378.0",
-				"@aws-sdk/util-user-agent-node": "3.378.0",
-				"@smithy/config-resolver": "^2.0.1",
-				"@smithy/fetch-http-handler": "^2.0.1",
-				"@smithy/hash-node": "^2.0.1",
-				"@smithy/invalid-dependency": "^2.0.1",
-				"@smithy/middleware-content-length": "^2.0.1",
-				"@smithy/middleware-endpoint": "^2.0.1",
-				"@smithy/middleware-retry": "^2.0.1",
-				"@smithy/middleware-serde": "^2.0.1",
-				"@smithy/middleware-stack": "^2.0.0",
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/node-http-handler": "^2.0.1",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/smithy-client": "^2.0.1",
-				"@smithy/types": "^2.0.2",
-				"@smithy/url-parser": "^2.0.1",
-				"@smithy/util-base64": "^2.0.0",
-				"@smithy/util-body-length-browser": "^2.0.0",
-				"@smithy/util-body-length-node": "^2.0.0",
-				"@smithy/util-defaults-mode-browser": "^2.0.1",
-				"@smithy/util-defaults-mode-node": "^2.0.1",
-				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.1.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.10",
+				"@smithy/util-defaults-mode-node": "^2.0.12",
+				"@smithy/util-retry": "^2.0.2",
 				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/client-sts": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.382.0.tgz",
-			"integrity": "sha512-G5wgahrOqmrljjyLVGASIZUXIIdalbCo0z4PuFHdb2R2CVfwO8renfgrmk4brT9tIxIfen5bRA7ftXMe7yrgRA==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.421.0.tgz",
+			"integrity": "sha512-/92NOZMcdkBcvGrINk5B/l+6DGcVzYE4Ab3ME4vcY9y//u2gd0yNn5YYRSzzjVBLvhDP3u6CbTfLX2Bm4qihPw==",
 			"optional": true,
 			"requires": {
 				"@aws-crypto/sha256-browser": "3.0.0",
 				"@aws-crypto/sha256-js": "3.0.0",
-				"@aws-sdk/credential-provider-node": "3.382.0",
-				"@aws-sdk/middleware-host-header": "3.379.1",
-				"@aws-sdk/middleware-logger": "3.378.0",
-				"@aws-sdk/middleware-recursion-detection": "3.378.0",
-				"@aws-sdk/middleware-sdk-sts": "3.379.1",
-				"@aws-sdk/middleware-signing": "3.379.1",
-				"@aws-sdk/middleware-user-agent": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
-				"@aws-sdk/util-endpoints": "3.382.0",
-				"@aws-sdk/util-user-agent-browser": "3.378.0",
-				"@aws-sdk/util-user-agent-node": "3.378.0",
-				"@smithy/config-resolver": "^2.0.1",
-				"@smithy/fetch-http-handler": "^2.0.1",
-				"@smithy/hash-node": "^2.0.1",
-				"@smithy/invalid-dependency": "^2.0.1",
-				"@smithy/middleware-content-length": "^2.0.1",
-				"@smithy/middleware-endpoint": "^2.0.1",
-				"@smithy/middleware-retry": "^2.0.1",
-				"@smithy/middleware-serde": "^2.0.1",
-				"@smithy/middleware-stack": "^2.0.0",
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/node-http-handler": "^2.0.1",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/smithy-client": "^2.0.1",
-				"@smithy/types": "^2.0.2",
-				"@smithy/url-parser": "^2.0.1",
+				"@aws-sdk/credential-provider-node": "3.421.0",
+				"@aws-sdk/middleware-host-header": "3.418.0",
+				"@aws-sdk/middleware-logger": "3.418.0",
+				"@aws-sdk/middleware-recursion-detection": "3.418.0",
+				"@aws-sdk/middleware-sdk-sts": "3.418.0",
+				"@aws-sdk/middleware-signing": "3.418.0",
+				"@aws-sdk/middleware-user-agent": "3.418.0",
+				"@aws-sdk/region-config-resolver": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
+				"@aws-sdk/util-endpoints": "3.418.0",
+				"@aws-sdk/util-user-agent-browser": "3.418.0",
+				"@aws-sdk/util-user-agent-node": "3.418.0",
+				"@smithy/config-resolver": "^2.0.10",
+				"@smithy/fetch-http-handler": "^2.1.5",
+				"@smithy/hash-node": "^2.0.9",
+				"@smithy/invalid-dependency": "^2.0.9",
+				"@smithy/middleware-content-length": "^2.0.11",
+				"@smithy/middleware-endpoint": "^2.0.9",
+				"@smithy/middleware-retry": "^2.0.12",
+				"@smithy/middleware-serde": "^2.0.9",
+				"@smithy/middleware-stack": "^2.0.2",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/node-http-handler": "^2.1.5",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/smithy-client": "^2.1.6",
+				"@smithy/types": "^2.3.3",
+				"@smithy/url-parser": "^2.0.9",
 				"@smithy/util-base64": "^2.0.0",
 				"@smithy/util-body-length-browser": "^2.0.0",
-				"@smithy/util-body-length-node": "^2.0.0",
-				"@smithy/util-defaults-mode-browser": "^2.0.1",
-				"@smithy/util-defaults-mode-node": "^2.0.1",
-				"@smithy/util-retry": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.1.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.10",
+				"@smithy/util-defaults-mode-node": "^2.0.12",
+				"@smithy/util-retry": "^2.0.2",
 				"@smithy/util-utf8": "^2.0.0",
 				"fast-xml-parser": "4.2.5",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/credential-provider-cognito-identity": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.382.0.tgz",
-			"integrity": "sha512-fEsmPSylpQdALSS1pKMa9QghMk9xFiQCanmUWbQ7ETkcjuYuc/DK6GIA0pRjq/BROJJNSxKrSxt3TZPzVpvb3w==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.421.0.tgz",
+			"integrity": "sha512-x+C7nonKomdBAljTAPtqhU6Xzzaqy08PV1vO5Cp/YYMye+uOGQ2+1x7cfaY5uIHZbbNRUhCmUBKGnwsUyTB1cQ==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/client-cognito-identity": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/client-cognito-identity": "3.421.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/credential-provider-env": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.378.0.tgz",
-			"integrity": "sha512-B2OVdO9kBClDwGgWTBLAQwFV8qYTYGyVujg++1FZFSFMt8ORFdZ5fNpErvJtiSjYiOOQMzyBeSNhKyYNXCiJjQ==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.418.0.tgz",
+			"integrity": "sha512-e74sS+x63EZUBO+HaI8zor886YdtmULzwKdctsZp5/37Xho1CVUNtEC+fYa69nigBD9afoiH33I4JggaHgrekQ==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/credential-provider-ini": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.382.0.tgz",
-			"integrity": "sha512-31pi44WWri2WQmagqptUv7x3Nq8pQ6H06OCQx5goEm77SosSdwQwyBPrS9Pg0yI9aljFAxF+rZ75degsCorbQg==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.421.0.tgz",
+			"integrity": "sha512-J5yH/gkpAk6FMeH5F9u5Nr6oG+97tj1kkn5q49g3XMbtWw7GiynadxdtoRBCeIg1C7o2LOQx4B1AnhNhIw1z/g==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/credential-provider-env": "3.378.0",
-				"@aws-sdk/credential-provider-process": "3.378.0",
-				"@aws-sdk/credential-provider-sso": "3.382.0",
-				"@aws-sdk/credential-provider-web-identity": "3.378.0",
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/credential-provider-env": "3.418.0",
+				"@aws-sdk/credential-provider-process": "3.418.0",
+				"@aws-sdk/credential-provider-sso": "3.421.0",
+				"@aws-sdk/credential-provider-web-identity": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/credential-provider-imds": "^2.0.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/shared-ini-file-loader": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/shared-ini-file-loader": "^2.0.6",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/credential-provider-node": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.382.0.tgz",
-			"integrity": "sha512-q6AWCCb0E0cH/Y5Dtln0QssbCBXDbV4PoTV3EdRuGoJcHyNfHJ8X0mqcc7k44wG4Piazu+ufZThvn43W7W9a4g==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.421.0.tgz",
+			"integrity": "sha512-g1dvdvfDj0u8B/gOsHR3o1arP4O4QE/dFm2IJBYr/eUdKISMUgbQULWtg4zdtAf0Oz4xN0723i7fpXAF1gTnRA==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/credential-provider-env": "3.378.0",
-				"@aws-sdk/credential-provider-ini": "3.382.0",
-				"@aws-sdk/credential-provider-process": "3.378.0",
-				"@aws-sdk/credential-provider-sso": "3.382.0",
-				"@aws-sdk/credential-provider-web-identity": "3.378.0",
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/credential-provider-env": "3.418.0",
+				"@aws-sdk/credential-provider-ini": "3.421.0",
+				"@aws-sdk/credential-provider-process": "3.418.0",
+				"@aws-sdk/credential-provider-sso": "3.421.0",
+				"@aws-sdk/credential-provider-web-identity": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/credential-provider-imds": "^2.0.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/shared-ini-file-loader": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/shared-ini-file-loader": "^2.0.6",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/credential-provider-process": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.378.0.tgz",
-			"integrity": "sha512-KFTIy7u+wXj3eDua4rgS0tODzMnXtXhAm1RxzCW9FL5JLBBrd82ymCj1Dp72217Sw5Do6NjCnDTTNkCHZMA77w==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.418.0.tgz",
+			"integrity": "sha512-xPbdm2WKz1oH6pTkrJoUmr3OLuqvvcPYTQX0IIlc31tmDwDWPQjXGGFD/vwZGIZIkKaFpFxVMgAzfFScxox7dw==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/shared-ini-file-loader": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/shared-ini-file-loader": "^2.0.6",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/credential-provider-sso": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.382.0.tgz",
-			"integrity": "sha512-tKCQKqxnAHeRD7pQNmDmLWwC7pt5koo6yiQTVQ382U+8xx7BNsApE1zdC4LrtrVN1FYqVbw5kXjYFtSCtaUxGA==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.421.0.tgz",
+			"integrity": "sha512-f8T3L5rhImL6T6RTSvbOxaWw9k2fDOT2DZbNjcPz9ITWmwXj2NNbdHGWuRi3dv2HoY/nW2IJdNxnhdhbn6Fc1A==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/client-sso": "3.382.0",
-				"@aws-sdk/token-providers": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/client-sso": "3.421.0",
+				"@aws-sdk/token-providers": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/shared-ini-file-loader": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/shared-ini-file-loader": "^2.0.6",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/credential-provider-web-identity": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.378.0.tgz",
-			"integrity": "sha512-GWjydOszhc4xDF8xuPtBvboglXQr0gwCW1oHAvmLcOT38+Hd6qnKywnMSeoXYRPgoKfF9TkWQgW1jxplzCG0UA==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.418.0.tgz",
+			"integrity": "sha512-do7ang565n9p3dS1JdsQY01rUfRx8vkxQqz5M8OlcEHBNiCdi2PvSjNwcBdrv/FKkyIxZb0TImOfBSt40hVdxQ==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/credential-providers": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.382.0.tgz",
-			"integrity": "sha512-+emgPCb8t5ODLpE1GeCkKaI6lx9M3RLQCYBGYkm/2o8FyvNeob9IBs6W8ufUTlnl4YRdKjDOlcfDtS00wCVHfA==",
+			"version": "3.421.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.421.0.tgz",
+			"integrity": "sha512-Mhz3r2N0YlOAhb1ZZYrP76VA1aIlJZw3IAwYwlS+hO4sAwp8iY6wCKiumqplXkVgK+ObLxlS9W/aW+2SAKsB7w==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/client-cognito-identity": "3.382.0",
-				"@aws-sdk/client-sso": "3.382.0",
-				"@aws-sdk/client-sts": "3.382.0",
-				"@aws-sdk/credential-provider-cognito-identity": "3.382.0",
-				"@aws-sdk/credential-provider-env": "3.378.0",
-				"@aws-sdk/credential-provider-ini": "3.382.0",
-				"@aws-sdk/credential-provider-node": "3.382.0",
-				"@aws-sdk/credential-provider-process": "3.378.0",
-				"@aws-sdk/credential-provider-sso": "3.382.0",
-				"@aws-sdk/credential-provider-web-identity": "3.378.0",
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/client-cognito-identity": "3.421.0",
+				"@aws-sdk/client-sso": "3.421.0",
+				"@aws-sdk/client-sts": "3.421.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.421.0",
+				"@aws-sdk/credential-provider-env": "3.418.0",
+				"@aws-sdk/credential-provider-ini": "3.421.0",
+				"@aws-sdk/credential-provider-node": "3.421.0",
+				"@aws-sdk/credential-provider-process": "3.418.0",
+				"@aws-sdk/credential-provider-sso": "3.421.0",
+				"@aws-sdk/credential-provider-web-identity": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/credential-provider-imds": "^2.0.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/middleware-host-header": {
-			"version": "3.379.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.379.1.tgz",
-			"integrity": "sha512-LI4KpAFWNWVr2aH2vRVblr0Y8tvDz23lj8LOmbDmCrzd5M21nxuocI/8nEAQj55LiTIf9Zs+dHCdsyegnFXdrA==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.418.0.tgz",
+			"integrity": "sha512-LrMTdzalkPw/1ujLCKPLwCGvPMCmT4P+vOZQRbSEVZPnlZk+Aj++aL/RaHou0jL4kJH3zl8iQepriBt4a7UvXQ==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.378.0",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/types": "3.418.0",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/middleware-logger": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.378.0.tgz",
-			"integrity": "sha512-l1DyaDLm3KeBMNMuANI3scWh8Xvu248x+vw6Z7ExWOhGXFmQ1MW7YvASg/SdxWkhlF9HmkkTif1LdMB22x6QDA==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.418.0.tgz",
+			"integrity": "sha512-StKGmyPVfoO/wdNTtKemYwoJsqIl4l7oqarQY7VSf2Mp3mqaa+njLViHsQbirYpyqpgUEusOnuTlH5utxJ1NsQ==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.378.0",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/types": "3.418.0",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/middleware-recursion-detection": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.378.0.tgz",
-			"integrity": "sha512-mUMfHAz0oGNIWiTZHTVJb+I515Hqs2zx1j36Le4MMiiaMkPW1SRUF1FIwGuc1wh6E8jB5q+XfEMriDjRi4TZRA==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.418.0.tgz",
+			"integrity": "sha512-kKFrIQglBLUFPbHSDy1+bbe3Na2Kd70JSUC3QLMbUHmqipXN8KeXRfAj7vTv97zXl0WzG0buV++WcNwOm1rFjg==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.378.0",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/types": "3.418.0",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/middleware-sdk-sts": {
-			"version": "3.379.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.379.1.tgz",
-			"integrity": "sha512-SK3gSyT0XbLiY12+AjLFYL9YngxOXHnZF3Z33Cdd4a+AUYrVBV7JBEEGD1Nlwrcmko+3XgaKlmgUaR5s91MYvg==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.418.0.tgz",
+			"integrity": "sha512-cW8ijrCTP+mgihvcq4+TbhAcE/we5lFl4ydRqvTdtcSnYQAVQADg47rnTScQiFsPFEB3NKq7BGeyTJF9MKolPA==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/middleware-signing": "3.379.1",
-				"@aws-sdk/types": "3.378.0",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/middleware-signing": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/middleware-signing": {
-			"version": "3.379.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.379.1.tgz",
-			"integrity": "sha512-kBk2ZUvR84EM4fICjr8K+Ykpf8SI1UzzPp2/UVYZ0X+4H/ZCjfSqohGRwHykMqeplne9qHSL7/rGJs1H3l3gPg==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.418.0.tgz",
+			"integrity": "sha512-onvs5KoYQE8OlOE740RxWBGtsUyVIgAo0CzRKOQO63ZEYqpL1Os+MS1CGzdNhvQnJgJruE1WW+Ix8fjN30zKPA==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/types": "3.418.0",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/protocol-http": "^2.0.1",
+				"@smithy/protocol-http": "^3.0.5",
 				"@smithy/signature-v4": "^2.0.0",
-				"@smithy/types": "^2.0.2",
-				"@smithy/util-middleware": "^2.0.0",
+				"@smithy/types": "^2.3.3",
+				"@smithy/util-middleware": "^2.0.2",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/middleware-user-agent": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.382.0.tgz",
-			"integrity": "sha512-LFRW1jmXOrOAd3911ktn6oaYmuurNnulbdRMOUdwz99GGdLVFipQhOi9idKswb8IOhPa4jEVQt25Kcv7ctvu0A==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.418.0.tgz",
+			"integrity": "sha512-Jdcztg9Tal9SEAL0dKRrnpKrm6LFlWmAhvuwv0dQ7bNTJxIxyEFbpqdgy7mpQHsLVZgq1Aad/7gT/72c9igyZw==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.378.0",
-				"@aws-sdk/util-endpoints": "3.382.0",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/types": "3.418.0",
+				"@aws-sdk/util-endpoints": "3.418.0",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/types": "^2.3.3",
+				"tslib": "^2.5.0"
+			}
+		},
+		"@aws-sdk/region-config-resolver": {
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.418.0.tgz",
+			"integrity": "sha512-lJRZ/9TjZU6yLz+mAwxJkcJZ6BmyYoIJVo1p5+BN//EFdEmC8/c0c9gXMRzfISV/mqWSttdtccpAyN4/goHTYA==",
+			"optional": true,
+			"requires": {
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/types": "^2.3.3",
+				"@smithy/util-config-provider": "^2.0.0",
+				"@smithy/util-middleware": "^2.0.2",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/token-providers": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.382.0.tgz",
-			"integrity": "sha512-axn4IyPpHdkXi8G06KCB3tPz79DipZFFH9N9YVDpLMnDYTdfX36HGdYzINaQc+z+XPbEpa1ZpoIzWScHRjFjdg==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.418.0.tgz",
+			"integrity": "sha512-9P7Q0VN0hEzTngy3Sz5eya2qEOEf0Q8qf1vB3um0gE6ID6EVAdz/nc/DztfN32MFxk8FeVBrCP5vWdoOzmd72g==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/client-sso-oidc": "3.382.0",
-				"@aws-sdk/types": "3.378.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/middleware-host-header": "3.418.0",
+				"@aws-sdk/middleware-logger": "3.418.0",
+				"@aws-sdk/middleware-recursion-detection": "3.418.0",
+				"@aws-sdk/middleware-user-agent": "3.418.0",
+				"@aws-sdk/types": "3.418.0",
+				"@aws-sdk/util-endpoints": "3.418.0",
+				"@aws-sdk/util-user-agent-browser": "3.418.0",
+				"@aws-sdk/util-user-agent-node": "3.418.0",
+				"@smithy/config-resolver": "^2.0.10",
+				"@smithy/fetch-http-handler": "^2.1.5",
+				"@smithy/hash-node": "^2.0.9",
+				"@smithy/invalid-dependency": "^2.0.9",
+				"@smithy/middleware-content-length": "^2.0.11",
+				"@smithy/middleware-endpoint": "^2.0.9",
+				"@smithy/middleware-retry": "^2.0.12",
+				"@smithy/middleware-serde": "^2.0.9",
+				"@smithy/middleware-stack": "^2.0.2",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/node-http-handler": "^2.1.5",
 				"@smithy/property-provider": "^2.0.0",
-				"@smithy/shared-ini-file-loader": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/shared-ini-file-loader": "^2.0.6",
+				"@smithy/smithy-client": "^2.1.6",
+				"@smithy/types": "^2.3.3",
+				"@smithy/url-parser": "^2.0.9",
+				"@smithy/util-base64": "^2.0.0",
+				"@smithy/util-body-length-browser": "^2.0.0",
+				"@smithy/util-body-length-node": "^2.1.0",
+				"@smithy/util-defaults-mode-browser": "^2.0.10",
+				"@smithy/util-defaults-mode-node": "^2.0.12",
+				"@smithy/util-retry": "^2.0.2",
+				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/types": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.378.0.tgz",
-			"integrity": "sha512-qP0CvR/ItgktmN8YXpGQglzzR/6s0nrsQ4zIfx3HMwpsBTwuouYahcCtF1Vr82P4NFcoDA412EJahJ2pIqEd+w==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.418.0.tgz",
+			"integrity": "sha512-y4PQSH+ulfFLY0+FYkaK4qbIaQI9IJNMO2xsxukW6/aNoApNymN1D2FSi2la8Qbp/iPjNDKsG8suNPm9NtsWXQ==",
 			"optional": true,
 			"requires": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/util-endpoints": {
-			"version": "3.382.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.382.0.tgz",
-			"integrity": "sha512-flajPyjmjNG67fXk7l4GoTB/7J11VBqtFZXuuAZKhKU07Ia3IQupsFqNf5lV8D44ZgjnKH0fTGnv3dUALjW7Wg==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.418.0.tgz",
+			"integrity": "sha512-sYSDwRTl7yE7LhHkPzemGzmIXFVHSsi3AQ1KeNEk84eBqxMHHcCc2kqklaBk2roXWe50QDgRMy1ikZUxvtzNHQ==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.378.0",
+				"@aws-sdk/types": "3.418.0",
 				"tslib": "^2.5.0"
 			}
 		},
@@ -2623,26 +2638,26 @@
 			}
 		},
 		"@aws-sdk/util-user-agent-browser": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.378.0.tgz",
-			"integrity": "sha512-FSCpagzftK1W+m7Ar6lpX7/Gr9y5P56nhFYz8U4EYQ4PkufS6czWX9YW+/FA5OYV0vlQ/SvPqMnzoHIPUNhZrQ==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.418.0.tgz",
+			"integrity": "sha512-c4p4mc0VV/jIeNH0lsXzhJ1MpWRLuboGtNEpqE4s1Vl9ck2amv9VdUUZUmHbg+bVxlMgRQ4nmiovA4qIrqGuyg==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.378.0",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/types": "3.418.0",
+				"@smithy/types": "^2.3.3",
 				"bowser": "^2.11.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@aws-sdk/util-user-agent-node": {
-			"version": "3.378.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.378.0.tgz",
-			"integrity": "sha512-IdwVJV0E96MkJeFte4dlWqvB+oiqCiZ5lOlheY3W9NynTuuX0GGYNC8Y9yIsV8Oava1+ujpJq0ww6qXdYxmO4A==",
+			"version": "3.418.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.418.0.tgz",
+			"integrity": "sha512-BXMskXFtg+dmzSCgmnWOffokxIbPr1lFqa1D9kvM3l3IFRiFGx2IyDg+8MAhq11aPDLvoa/BDuQ0Yqma5izOhg==",
 			"optional": true,
 			"requires": {
-				"@aws-sdk/types": "3.378.0",
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@aws-sdk/types": "3.418.0",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
@@ -2745,6 +2760,15 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
+		"@mongodb-js/saslprep": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+			"integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+			"optional": true,
+			"requires": {
+				"sparse-bitfield": "^3.0.3"
+			}
+		},
 		"@sapphire/async-queue": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
@@ -2765,84 +2789,85 @@
 			"integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA=="
 		},
 		"@smithy/abort-controller": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.1.tgz",
-			"integrity": "sha512-0s7XjIbsTwZyUW9OwXQ8J6x1UiA1TNCh60Vaw56nHahL7kUZsLhmTlWiaxfLkFtO2Utkj8YewcpHTYpxaTzO+w==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.9.tgz",
+			"integrity": "sha512-8liHOEbx99xcy4VndeQNQhyA0LS+e7UqsuRnDTSIA26IKBv/7vA9w09KOd4fgNULrvX0r3WpA6cwsQTRJpSWkg==",
 			"optional": true,
 			"requires": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/config-resolver": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.1.tgz",
-			"integrity": "sha512-l83Pm7hV+8CBQOCmBRopWDtF+CURUJol7NsuPYvimiDhkC2F8Ba9T1imSFE+pD1UIJ9jlsDPAnZfPJT5cjnuEw==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.10.tgz",
+			"integrity": "sha512-MwToDsCltHjumkCuRn883qoNeJUawc2b8sX9caSn5vLz6J5crU1IklklNxWCaMO2z2nDL91Po4b/aI1eHv5PfA==",
 			"optional": true,
 			"requires": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-config-provider": "^2.0.0",
-				"@smithy/util-middleware": "^2.0.0",
+				"@smithy/util-middleware": "^2.0.2",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/credential-provider-imds": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.1.tgz",
-			"integrity": "sha512-8VxriuRINNEfVZjEFKBY75y9ZWAx73DZ5K/u+3LmB6r8WR2h3NaFxFKMlwlq0uzNdGhD1ouKBn9XWEGYHKiPLw==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.12.tgz",
+			"integrity": "sha512-S3lUNe+2fEFwKcmiQniXGPXt69vaHvQCw8kYQOBL4OvJsgwfpkIYDZdroHbTshYi0M6WaKL26Mw+hvgma6dZqA==",
 			"optional": true,
 			"requires": {
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/property-provider": "^2.0.1",
-				"@smithy/types": "^2.0.2",
-				"@smithy/url-parser": "^2.0.1",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/property-provider": "^2.0.10",
+				"@smithy/types": "^2.3.3",
+				"@smithy/url-parser": "^2.0.9",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/eventstream-codec": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.1.tgz",
-			"integrity": "sha512-/IiNB7gQM2y2ZC/GAWOWDa8+iXfhr1g9Xe5979cQEOdCWDISvrAiv18cn3OtIQUhbYOR3gm7QtCpkq1to2takQ==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.9.tgz",
+			"integrity": "sha512-sy0pcbKnawt1iu+qCoSFbs/h9PAaUgvlJEO3lqkE1HFFj4p5RgL98vH+9CyDoj6YY82cG5XsorFmcLqQJHTOYw==",
 			"optional": true,
 			"requires": {
 				"@aws-crypto/crc32": "3.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-hex-encoding": "^2.0.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/fetch-http-handler": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.1.tgz",
-			"integrity": "sha512-/SoU/ClazgcdOxgE4zA7RX8euiELwpsrKCSvulVQvu9zpmqJRyEJn8ZTWYFV17/eHOBdHTs9kqodhNhsNT+cUw==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.1.5.tgz",
+			"integrity": "sha512-BIeCHGfr5JCGN+EMTwZK74ELvjPXOIrI7OLM5OhZJJ6AmZyRv2S9ANJk18AtLwht0TsSm+8WoXIEp8LuxNgUyA==",
 			"optional": true,
 			"requires": {
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/querystring-builder": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/querystring-builder": "^2.0.9",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-base64": "^2.0.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/hash-node": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.1.tgz",
-			"integrity": "sha512-oTKYimQdF4psX54ZonpcIE+MXjMUWFxLCNosjPkJPFQ9whRX0K/PFX/+JZGRQh3zO9RlEOEUIbhy9NO+Wha6hw==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.9.tgz",
+			"integrity": "sha512-XP3yWd5wyCtiVmsY5Nuq/FUwyCEQ6YG7DsvRh7ThldNukGpCzyFdP8eivZJVjn4Fx7oYrrOnVoYZ0WEgpW1AvQ==",
 			"optional": true,
 			"requires": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-buffer-from": "^2.0.0",
 				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/invalid-dependency": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.1.tgz",
-			"integrity": "sha512-2q/Eb0AE662zwyMV+z+TL7deBwcHCgaZZGc0RItamBE8kak3MzCi/EZCNoFWoBfxgQ4jfR12wm8KKsSXhJzJtQ==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.9.tgz",
+			"integrity": "sha512-RuJqhYf8nViK96IIO9JbTtjDUuFItVfuuJhWw2yk7fv67yltQ7fZD6IQ2OsHHluoVmstnQJuCg5raXJR696Ubw==",
 			"optional": true,
 			"requires": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
@@ -2856,190 +2881,195 @@
 			}
 		},
 		"@smithy/middleware-content-length": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.1.tgz",
-			"integrity": "sha512-IZhRSk5GkVBcrKaqPXddBS2uKhaqwBgaSgbBb1OJyGsKe7SxRFbclWS0LqOR9fKUkDl+3lL8E2ffpo6EQg0igw==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.11.tgz",
+			"integrity": "sha512-Malj4voNTL4+a5ZL3a6+Ij7JTUMTa2R7c3ZIBzMxN5OUUgAspU7uFi1Q97f4B0afVh2joQBAWH5IQJUG25nl8g==",
 			"optional": true,
 			"requires": {
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/middleware-endpoint": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.1.tgz",
-			"integrity": "sha512-uz/KI1MBd9WHrrkVFZO4L4Wyv24raf0oR4EsOYEeG5jPJO5U+C7MZGLcMxX8gWERDn1sycBDqmGv8fjUMLxT6w==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.9.tgz",
+			"integrity": "sha512-72/o8R6AAO4+nyTI6h4z6PYGTSA4dr1M7tZz29U8DEUHuh1YkhC77js0P6RyF9G0wDLuYqxb+Yh0crI5WG2pJg==",
 			"optional": true,
 			"requires": {
-				"@smithy/middleware-serde": "^2.0.1",
-				"@smithy/types": "^2.0.2",
-				"@smithy/url-parser": "^2.0.1",
-				"@smithy/util-middleware": "^2.0.0",
+				"@smithy/middleware-serde": "^2.0.9",
+				"@smithy/types": "^2.3.3",
+				"@smithy/url-parser": "^2.0.9",
+				"@smithy/util-middleware": "^2.0.2",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/middleware-retry": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.1.tgz",
-			"integrity": "sha512-NKHF4i0gjSyjO6C0ZyjEpNqzGgIu7s8HOK6oT/1Jqws2Q1GynR1xV8XTUs1gKXeaNRzbzKQRewHHmfPwZjOtHA==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.12.tgz",
+			"integrity": "sha512-YQ/ufXX4/d9/+Jf1QQ4J+CVeupC7BW52qldBTvRV33PDX9vxndlAwkFwzBcmnUFC3Hjf1//HW6I77EItcjNSCA==",
 			"optional": true,
 			"requires": {
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/service-error-classification": "^2.0.0",
-				"@smithy/types": "^2.0.2",
-				"@smithy/util-middleware": "^2.0.0",
-				"@smithy/util-retry": "^2.0.0",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/service-error-classification": "^2.0.2",
+				"@smithy/types": "^2.3.3",
+				"@smithy/util-middleware": "^2.0.2",
+				"@smithy/util-retry": "^2.0.2",
 				"tslib": "^2.5.0",
 				"uuid": "^8.3.2"
 			}
 		},
 		"@smithy/middleware-serde": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.1.tgz",
-			"integrity": "sha512-uKxPaC6ItH9ZXdpdqNtf8sda7GcU4SPMp0tomq/5lUg9oiMa/Q7+kD35MUrpKaX3IVXVrwEtkjCU9dogZ/RAUA==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.9.tgz",
+			"integrity": "sha512-GVbauxrr6WmtCaesakktg3t5LR/yDbajpC7KkWc8rtCpddMI4ShAVO5Q6DqwX8MDFi4CLaY8H7eTGcxhl3jbLg==",
 			"optional": true,
 			"requires": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/middleware-stack": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz",
-			"integrity": "sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.3.tgz",
+			"integrity": "sha512-AlhPmbwpkC4lQBVaVHXczmjFvsAhDHhrakqLt038qFLotnJcvDLhmMzAtu23alBeOSkKxkTQq0LsAt2N0WpAbw==",
 			"optional": true,
 			"requires": {
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/node-config-provider": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.1.tgz",
-			"integrity": "sha512-Zoel4CPkKRTQ2XxmozZUfqBYqjPKL53/SvTDhJHj+VBSiJy6MXRav1iDCyFPS92t40Uh+Yi+Km5Ch3hQ+c/zSA==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.12.tgz",
+			"integrity": "sha512-df9y9ywv+JmS40Y60ZqJ4jfZiTCmyHQffwzIqjBjLJLJl0imf9F6DWBd+jiEWHvlohR+sFhyY+KL/qzKgnAq1A==",
 			"optional": true,
 			"requires": {
-				"@smithy/property-provider": "^2.0.1",
-				"@smithy/shared-ini-file-loader": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/property-provider": "^2.0.10",
+				"@smithy/shared-ini-file-loader": "^2.0.11",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/node-http-handler": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.1.tgz",
-			"integrity": "sha512-Zv3fxk3p9tsmPT2CKMsbuwbbxnq2gzLDIulxv+yI6aE+02WPYorObbbe9gh7SW3weadMODL1vTfOoJ9yFypDzg==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.5.tgz",
+			"integrity": "sha512-52uF+BrZaFiBh+NT/bADiVDCQO91T+OwDRsuaAeWZC1mlCXFjAPPQdxeQohtuYOe9m7mPP/xIMNiqbe8jvndHA==",
 			"optional": true,
 			"requires": {
-				"@smithy/abort-controller": "^2.0.1",
-				"@smithy/protocol-http": "^2.0.1",
-				"@smithy/querystring-builder": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/abort-controller": "^2.0.9",
+				"@smithy/protocol-http": "^3.0.5",
+				"@smithy/querystring-builder": "^2.0.9",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/property-provider": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.1.tgz",
-			"integrity": "sha512-pmJRyY9SF6sutWIktIhe+bUdSQDxv/qZ4mYr3/u+u45riTPN7nmRxPo+e4sjWVoM0caKFjRSlj3tf5teRFy0Vg==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.10.tgz",
+			"integrity": "sha512-YMBVfh0ZMmJtbsUn+WfSwR32iRljZPdRN0Tn2GAcdJ+ejX8WrBXD7Z0jIkQDrQZr8fEuuv5x8WxMIj+qVbsPQw==",
 			"optional": true,
 			"requires": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/protocol-http": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.1.tgz",
-			"integrity": "sha512-mrkMAp0wtaDEIkgRObWYxI1Kun1tm6Iu6rK+X4utb6Ah7Uc3Kk4VIWwK/rBHdYGReiLIrxFCB1rq4a2gyZnSgg==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.5.tgz",
+			"integrity": "sha512-3t3fxj+ip4EPHRC2fQ0JimMxR/qCQ1LSQJjZZVZFgROnFLYWPDgUZqpoi7chr+EzatxJVXF/Rtoi5yLHOWCoZQ==",
 			"optional": true,
 			"requires": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/querystring-builder": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.1.tgz",
-			"integrity": "sha512-bp+93WFzx1FojVEIeFPtG0A1pKsFdCUcZvVdZdRlmNooOUrz9Mm9bneRd8hDwAQ37pxiZkCOxopSXXRQN10mYw==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.9.tgz",
+			"integrity": "sha512-Yt6CPF4j3j1cuwod/DRflbuXxBFjJm7gAjy6W1RE21Rz5/kfGFqiZBXWmmXwGtnnhiLThYwoHK4S6/TQtnx0Fg==",
 			"optional": true,
 			"requires": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-uri-escape": "^2.0.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/querystring-parser": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.1.tgz",
-			"integrity": "sha512-h+e7k1z+IvI2sSbUBG9Aq46JsgLl4UqIUl6aigAlRBj+P6ocNXpM6Yn1vMBw5ijtXeZbYpd1YvCxwDgdw3jhmg==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.9.tgz",
+			"integrity": "sha512-U6z4N743s4vrcxPW8p8+reLV0PjMCYEyb1/wtMVvv3VnbJ74gshdI8SR1sBnEh95cF8TxonmX5IxY25tS9qGfg==",
 			"optional": true,
 			"requires": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/service-error-classification": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz",
-			"integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==",
-			"optional": true
-		},
-		"@smithy/shared-ini-file-loader": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.1.tgz",
-			"integrity": "sha512-a463YiZrPGvM+F336rIF8pLfQsHAdCRAn/BiI/EWzg5xLoxbC7GSxIgliDDXrOu0z8gT3nhVsif85eU6jyct3A==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.2.tgz",
+			"integrity": "sha512-GTUd2j63gKy7A+ggvSdn2hc4sejG7LWfE+ZMF17vzWoNyqERWbRP7HTPS0d0Lwg1p6OQCAzvNigSrEIWVFt6iA==",
 			"optional": true,
 			"requires": {
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3"
+			}
+		},
+		"@smithy/shared-ini-file-loader": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.11.tgz",
+			"integrity": "sha512-Sf0u5C5px6eykXi6jImDTp+edvG3REtPjXnFWU/J+b7S2wkXwUqFXqBL5DdM4zC1F+M8u57ZT7NRqDwMOw7/Tw==",
+			"optional": true,
+			"requires": {
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/signature-v4": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.1.tgz",
-			"integrity": "sha512-jztv5Mirca42ilxmMDjzLdXcoAmRhZskGafGL49sRo5u7swEZcToEFrq6vtX5YMbSyTVrE9Teog5EFexY5Ff2Q==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.9.tgz",
+			"integrity": "sha512-RkHP0joSI1j2EI+mU55sOi33/aMMkKdL9ZY+SWrPxsiCe1oyzzuy79Tpn8X7uT+t0ilNmQlwPpkP/jUy940pEA==",
 			"optional": true,
 			"requires": {
-				"@smithy/eventstream-codec": "^2.0.1",
+				"@smithy/eventstream-codec": "^2.0.9",
 				"@smithy/is-array-buffer": "^2.0.0",
-				"@smithy/types": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-hex-encoding": "^2.0.0",
-				"@smithy/util-middleware": "^2.0.0",
+				"@smithy/util-middleware": "^2.0.2",
 				"@smithy/util-uri-escape": "^2.0.0",
 				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/smithy-client": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.1.tgz",
-			"integrity": "sha512-LHC5m6tYpEu1iNbONfvMbwtErboyTZJfEIPoD78Ei5MVr36vZQCaCla5mvo36+q/a2NAk2//fA5Rx3I1Kf7+lQ==",
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.7.tgz",
+			"integrity": "sha512-r6T/oiBQ8vCbGqObH4/h0YqD0jFB1hAS9KFRmuTfaNJueu/L2hjmjqFjv3PV5lkbNHTgUYraSv4cFQ1naxiELQ==",
 			"optional": true,
 			"requires": {
-				"@smithy/middleware-stack": "^2.0.0",
-				"@smithy/types": "^2.0.2",
-				"@smithy/util-stream": "^2.0.1",
+				"@smithy/middleware-stack": "^2.0.3",
+				"@smithy/types": "^2.3.3",
+				"@smithy/util-stream": "^2.0.12",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/types": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.0.2.tgz",
-			"integrity": "sha512-wcymEjIXQ9+NEfE5Yt5TInAqe1o4n+Nh+rh00AwoazppmUt8tdo6URhc5gkDcOYrcvlDVAZE7uG69nDpEGUKxw==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.3.tgz",
+			"integrity": "sha512-zTdIPR9PvFVNRdIKMQu4M5oyTaycIbUqLheQqaOi9rTWPkgjGO2wDBxMA1rBHQB81aqAEv+DbSS4jfKyQMnXRA==",
 			"optional": true,
 			"requires": {
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/url-parser": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.1.tgz",
-			"integrity": "sha512-NpHVOAwddo+OyyIoujDL9zGL96piHWrTNXqltWmBvlUoWgt1HPyBuKs6oHjioyFnNZXUqveTOkEEq0U5w6Uv8A==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.9.tgz",
+			"integrity": "sha512-NBnJ0NiY8z6E82Xd5VYUFQfKwK/wA/+QkKmpYUYP+cpH3aCzE6g2gvixd9vQKYjsIdRfNPCf+SFAozt8ljozOw==",
 			"optional": true,
 			"requires": {
-				"@smithy/querystring-parser": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/querystring-parser": "^2.0.9",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
@@ -3063,9 +3093,9 @@
 			}
 		},
 		"@smithy/util-body-length-node": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.0.0.tgz",
-			"integrity": "sha512-ZV7Z/WHTMxHJe/xL/56qZwSUcl63/5aaPAGjkfynJm4poILjdD4GmFI+V+YWabh2WJIjwTKZ5PNsuvPQKt93Mg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+			"integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
 			"optional": true,
 			"requires": {
 				"tslib": "^2.5.0"
@@ -3091,28 +3121,30 @@
 			}
 		},
 		"@smithy/util-defaults-mode-browser": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.1.tgz",
-			"integrity": "sha512-w72Qwsb+IaEYEFtYICn0Do42eFju78hTaBzzJfT107lFOPdbjWjKnFutV+6GL/nZd5HWXY7ccAKka++C3NrjHw==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.11.tgz",
+			"integrity": "sha512-0syV1Mz/mCQ7CG/MHKQfH+w86xq59jpD0EOXv5oe0WBXLmq2lWPpVHl2Y6+jQ+/9fYzyZ5NF+NC/WEIuiv690A==",
 			"optional": true,
 			"requires": {
-				"@smithy/property-provider": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/property-provider": "^2.0.10",
+				"@smithy/smithy-client": "^2.1.7",
+				"@smithy/types": "^2.3.3",
 				"bowser": "^2.11.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-defaults-mode-node": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.1.tgz",
-			"integrity": "sha512-dNF45caelEBambo0SgkzQ0v76m4YM+aFKZNTtSafy7P5dVF8TbjZuR2UX1A5gJABD9XK6lzN+v/9Yfzj/EDgGg==",
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.13.tgz",
+			"integrity": "sha512-6BtCHYdw5Z8r6KpW8tRCc3yURgvcQwfIEeHhR70BeSOfx8T/TXPPjb8A+K45+KASspa3fzrsSxeIwB0sAeMoHA==",
 			"optional": true,
 			"requires": {
-				"@smithy/config-resolver": "^2.0.1",
-				"@smithy/credential-provider-imds": "^2.0.1",
-				"@smithy/node-config-provider": "^2.0.1",
-				"@smithy/property-provider": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/config-resolver": "^2.0.10",
+				"@smithy/credential-provider-imds": "^2.0.12",
+				"@smithy/node-config-provider": "^2.0.12",
+				"@smithy/property-provider": "^2.0.10",
+				"@smithy/smithy-client": "^2.1.7",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
@@ -3126,33 +3158,35 @@
 			}
 		},
 		"@smithy/util-middleware": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.0.tgz",
-			"integrity": "sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.2.tgz",
+			"integrity": "sha512-UGPZM+Ja/vke5pc/S8G0LNiHpVirtjppsXO+GK9m9wbzRGzPJTfnZA/gERUUN/AfxEy/8SL7U1kd7u4t2X8K1w==",
 			"optional": true,
 			"requires": {
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-retry": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.0.tgz",
-			"integrity": "sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.2.tgz",
+			"integrity": "sha512-ovWiayUB38moZcLhSFFfUgB2IMb7R1JfojU20qSahjxAgfOZvDWme3eOYUMtAVnouZ9kYJiFgHLy27qRH4NeeA==",
 			"optional": true,
 			"requires": {
-				"@smithy/service-error-classification": "^2.0.0",
+				"@smithy/service-error-classification": "^2.0.2",
+				"@smithy/types": "^2.3.3",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.1.tgz",
-			"integrity": "sha512-2a0IOtwIKC46EEo7E7cxDN8u2jwOiYYJqcFKA6rd5rdXqKakHT2Gc+AqHWngr0IEHUfW92zX12wRQKwyoqZf2Q==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.12.tgz",
+			"integrity": "sha512-FOCpRLaj6gvSyUC5mJAACT+sPMPmp9sD1o+hVbUH/QxwZfulypA3ZIFdAg/59/IY0d/1Q4CTztsiHEB5LgjN4g==",
 			"optional": true,
 			"requires": {
-				"@smithy/fetch-http-handler": "^2.0.1",
-				"@smithy/node-http-handler": "^2.0.1",
-				"@smithy/types": "^2.0.2",
+				"@smithy/fetch-http-handler": "^2.1.5",
+				"@smithy/node-http-handler": "^2.1.5",
+				"@smithy/types": "^2.3.3",
 				"@smithy/util-base64": "^2.0.0",
 				"@smithy/util-buffer-from": "^2.0.0",
 				"@smithy/util-hex-encoding": "^2.0.0",
@@ -3210,9 +3244,9 @@
 			"integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
 		},
 		"@types/webidl-conversions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-			"integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.1.tgz",
+			"integrity": "sha512-8hKOnOan+Uu+NgMaCouhg3cT9x5fFZ92Jwf+uDLXLu/MFRbXxlWwGeQY7KVHkeSft6RvY+tdxklUBuyY9eIEKg=="
 		},
 		"@types/whatwg-url": {
 			"version": "8.2.2",
@@ -3444,14 +3478,14 @@
 			"optional": true
 		},
 		"mongodb": {
-			"version": "4.16.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.16.0.tgz",
-			"integrity": "sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==",
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.1.tgz",
+			"integrity": "sha512-MBuyYiPUPRTqfH2dV0ya4dcr2E5N52ocBuZ8Sgg/M030nGF78v855B3Z27mZJnp8PxjnUquEnAtjOsphgMZOlQ==",
 			"requires": {
 				"@aws-sdk/credential-providers": "^3.186.0",
+				"@mongodb-js/saslprep": "^1.1.0",
 				"bson": "^4.7.2",
-				"mongodb-connection-string-url": "^2.5.4",
-				"saslprep": "^1.0.3",
+				"mongodb-connection-string-url": "^2.6.0",
 				"socks": "^2.7.1"
 			}
 		},
@@ -3465,13 +3499,13 @@
 			}
 		},
 		"mongoose": {
-			"version": "6.11.5",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.11.5.tgz",
-			"integrity": "sha512-ZarPe1rCHG4aVb78xLuok4BBIm0HMz/Y/CjxYXCk3Qz1mEhS7bPMy6ZhSX2/Dng//R7ei8719j6K87UVM/1b3g==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.12.0.tgz",
+			"integrity": "sha512-sd/q83C6TBRPBrrD2A/POSbA/exbCFM2WOuY7Lf2JuIJFlHFG39zYSDTTAEiYlzIfahNOLmXPxBGFxdAch41Mw==",
 			"requires": {
 				"bson": "^4.7.2",
 				"kareem": "2.5.1",
-				"mongodb": "4.16.0",
+				"mongodb": "4.17.1",
 				"mpath": "0.9.0",
 				"mquery": "4.0.3",
 				"ms": "2.1.3",
@@ -3528,15 +3562,6 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-		},
-		"saslprep": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-			"optional": true,
-			"requires": {
-				"sparse-bitfield": "^3.0.3"
-			}
 		},
 		"sift": {
 			"version": "16.0.1",

--- a/scripts/matchsetup.py
+++ b/scripts/matchsetup.py
@@ -80,22 +80,27 @@ def main():
             print("player_id", player_id, "with ELO score of", new_elo_score, "but not queued in")
             continue
 
-        queue_player = queueplayers_collection.find_one({'discordId': player['discordId']})
-        if queue_player and 'matchMessageId' in queue_player:
+        queue_player_records = queueplayers_collection.find({'discordId': player['discordId']})
+        player_in_match = False
+        player_in_target_queue = False
+        for queue_player in queue_player_records:
+            if queue_player and 'matchMessageId' in queue_player:
+                player_in_match = True
+            elif queue_player and queue_player['messageId'] == queue_message_id:
+                player_in_target_queue = True
+                
+                
+
+        if player_in_match:
             print("Player is in a match and can not be queued up")
             continue
-        elif queue_player and queue_player['messageId'] == queue_message_id:
+        if player_in_target_queue:
             filter = {'_id': queue_player['_id']}
             new_position = { '$set' : {'queuePosition': i + 1} }
             queueplayers_collection.update_one(filter, new_position)
             print("Player", player_id, "already in a queue", queue_player['messageId'] + ".",  "Changed their ELO score to", str(new_elo_score) + ".", "New position in queue is", i + 1)      
             i += 1
             continue
-        elif queue_player:
-            print("Player is in another queue")
-            continue
-            
-
         queue_player = {
             'discordId': player_id,
             'messageId': queue_id,

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,0 +1,20 @@
+import { Client, CommandInteraction, SlashCommandBuilder } from "discord.js";
+import { SlashCommand } from "../types";
+import { leaderboard } from "#operations";
+import Player from "#schemas/player";
+
+const command: SlashCommand = {
+	data: new SlashCommandBuilder()
+		.setName("ping")
+		.setDescription("Ping the bot to make sure it is running"),
+	execute: async (interaction: CommandInteraction, client: Client) => {
+		// Retrieve the players from the database and sort by rating
+		// const players = await Player.find().sort("-rating");
+		// const playersPerPage = 25;
+		// var device: string = (interaction.options as any).getString("device");
+		await interaction.reply({content: "pong", ephemeral: true});
+	},
+	cooldown: 1,
+};
+
+export default command;

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -12,7 +12,7 @@ const command: SlashCommand = {
 		// const players = await Player.find().sort("-rating");
 		// const playersPerPage = 25;
 		// var device: string = (interaction.options as any).getString("device");
-		await interaction.reply({content: "pong", ephemeral: true});
+		await interaction.reply({ content: "pong", ephemeral: true });
 	},
 	cooldown: 1,
 };

--- a/src/operations/buttons/queueButtons.ts
+++ b/src/operations/buttons/queueButtons.ts
@@ -17,8 +17,8 @@ export const processQueue = async (interaction: ButtonInteraction, client: Clien
     const queueEmbed = EmbedBuilder.from(receivedEmbed);
     const playerQuery = Player.findOne<IPlayer>({ discordId: userId });
     const queueUserQuery = QueuePlayer.findOne<IQueuePlayer>().and([{ discordId: userId, messageId: interaction.message.id }]);
-    const queueUserInMatchQuery = QueuePlayer.findOne<IQueuePlayer>().and([{ discordId: userId }, { matchMessageId: {$exists: true } }])
-    const queueAllPlayers = QueuePlayer.find<IQueuePlayer>().and([{ messageId: interaction.message.id }, { matchMessageId: { $exists: false } }]).sort({queuePosition: 1});
+    const queueUserInMatchQuery = QueuePlayer.findOne<IQueuePlayer>().and([{ discordId: userId }, { matchMessageId: { $exists: true } }])
+    const queueAllPlayers = QueuePlayer.find<IQueuePlayer>().and([{ messageId: interaction.message.id }, { matchMessageId: { $exists: false } }]).sort({ queuePosition: 1 });
     const guildQuery = Guild.findOne<IGuild>({ guildId: interaction.guildId });
     const queueQuery = Queue.findOne<IQueue>({ messageId: interaction.message.id });
 
@@ -188,7 +188,7 @@ export const removeUserFromQueue = async (interaction: ButtonInteraction, overri
 
             try {
                 await QueuePlayer.deleteOne({ _id: queryResults[0][0]._id });
-                var updatedQueue = await QueuePlayer.find<IQueuePlayer>().and([{ messageId: interaction.message.id }, { matchMessageId: { $exists: false } }]).sort({queuePosition: 1});
+                var updatedQueue = await QueuePlayer.find<IQueuePlayer>().and([{ messageId: interaction.message.id }, { matchMessageId: { $exists: false } }]).sort({ queuePosition: 1 });
             } catch (error) {
                 mongoError(error as MongooseError);
                 console.log(`There was an error deleting the player from the queue in the database.`)
@@ -523,15 +523,15 @@ export const updateQueuePositions = async (updatedQueuePlayers: IQueuePlayer[]):
     }));
 };
 
-export const removeNewMatchPlayersFromOtherQueues = async (interaction: ButtonInteraction<CacheType>, queuePlayers: IQueuePlayer[])=>{
+export const removeNewMatchPlayersFromOtherQueues = async (interaction: ButtonInteraction<CacheType>, queuePlayers: IQueuePlayer[]) => {
     for (const qp of queuePlayers) {
         try {
             await QueuePlayer.deleteMany(
-                { discordId: qp.discordId,  messageId: { $ne: interaction.message.id }}
+                { discordId: qp.discordId, messageId: { $ne: interaction.message.id } }
             )
-		} catch (error) {
-			mongoError(error as MongooseError);
-			console.log(`There was an error removing the players from the queueplayers in the database.`);
-		}
+        } catch (error) {
+            mongoError(error as MongooseError);
+            console.log(`There was an error removing the players from the queueplayers in the database.`);
+        }
     }
 }


### PR DESCRIPTION
- Allows multi-queuing. When a match is launched, the user is removed from the queue, but their names remain until the queue is updated by someone pressing "Queue" or by removing a player.
- Fixed crash when 14+ players queue up by queuing them up but not putting them in the queue. Instead, they get a message in the channel saying they are queued and what position they are in.
- Can now check your position in the queue by pressing the "Queue" button while you are queued. This is useful for people who are in position 14+ who are in the queue but not shown.
- Fixed the bug that happens when a GM+ uses the "Remove Player" button. Before, when the button was used, someone had to remove themselves or queue up in order to allow a match to launch. This step is no longer required.
- Added a /ping command that can be used to check if the bot is up and running. If there is ever a doubt if the bot is down (and not just taking a long time), you can use this command. DO NOT SPAM THIS COMMAND.
